### PR TITLE
Install server if it is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -217,4 +217,7 @@ testVersion
 cleanup
 
 leap -h
-leap server install
+STANDALONE_DIR="/var/lib/tensorleap/standalone/storage"
+if [ ! -d "$STANDALONE_DIR" ]; then
+  leap server install
+fi


### PR DESCRIPTION
After installation there are 4 folders within standalone dir.
however after uninstall one folder is kept for logs hence we should ask if storage, manifests or registry is exists in order to indicate if it is already installed