### PR TITLE
Local build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,5 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run ShellCheck
-        run: shellcheck ./install.sh
+        uses: ludeeus/action-shellcheck@master
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
 
@@ -22,7 +22,7 @@ jobs:
         run: go build .
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
           only-new-issues: true
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,11 @@ test:
 .PHONY: update-server-api
 update-server-api:
 	@./scripts/update_server_api.sh ${NODE_SERVER_BUILDER_IMAGE} ${NODE_SERVER_BRANCH} 
+
+.PHONY: shellcheck-image
+shellcheck-image:
+	docker build -t shellcheck-image -f shellcheck.Dockerfile .
+
+.PHONY: shellcheck
+shellcheck:
+	docker run --rm -v `pwd`:/repo shellcheck-image

--- a/pkg/tensorleapapi/git_push.sh
+++ b/pkg/tensorleapapi/git_push.sh
@@ -43,9 +43,9 @@ if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
         echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
 
 fi

--- a/scripts/update_server_api.sh
+++ b/scripts/update_server_api.sh
@@ -10,11 +10,11 @@ NODE_SERVER_REPO=node-server
 NODE_SERVER_BRANCH=${2:-master}
 function get_image_name() {
     IMAGE_NAME=${DOCKER_REGISTRY}/${NODE_SERVER_REPO}
-    LAST_COMMIT_HASH=$(gh api repos/tensorleap/$NODE_SERVER_REPO/commits/$NODE_SERVER_BRANCH --jq '.sha')
-    IMAGE_TAG=$NODE_SERVER_BRANCH-$(echo $LAST_COMMIT_HASH | cut -c 1-8)
+    LAST_COMMIT_HASH="$(gh api "repos/tensorleap/$NODE_SERVER_REPO/commits/$NODE_SERVER_BRANCH" --jq '.sha')"
+    IMAGE_TAG="$NODE_SERVER_BRANCH-$(echo "$LAST_COMMIT_HASH" | cut -c 1-8)"
     IMAGE_BUILDER_TAG=${IMAGE_TAG}-builder
     IMAGE=$IMAGE_NAME:$IMAGE_BUILDER_TAG
-    echo $IMAGE
+    echo "$IMAGE"
 }
 
 IMAGE=$1
@@ -23,13 +23,13 @@ if [ -z "$IMAGE" ]; then
 fi
 
 echo "Pulling node server image: ${IMAGE}";
-docker pull ${IMAGE}
+docker pull "${IMAGE}"
 
 echo "Removing old server api...";
 rm -rf ./pkg/tensorleapapi
 
 echo "Generating server api...";
-docker run --rm -v $(pwd)/pkg/tensorleapapi:/usr/app/generated/tensorleapapi ${IMAGE} sh -c "npm run generate-go-client"
+docker run --rm -v "$(pwd)/pkg/tensorleapapi:/usr/app/generated/tensorleapapi" "${IMAGE}" sh -c "npm run generate-go-client"
 
 echo "Formatting code..."
 make fmt

--- a/shellcheck.Dockerfile
+++ b/shellcheck.Dockerfile
@@ -1,0 +1,11 @@
+# Use Alpine Linux for a minimal image
+FROM alpine:latest
+
+# Install shellcheck
+RUN apk add --no-cache shellcheck
+
+# Set the working directory inside the container
+WORKDIR /repo
+
+# By default, run shellcheck on all shell scripts in the working directory
+CMD find . -type f -name "*.sh" -exec shellcheck {} +


### PR DESCRIPTION
* Using shellcheck GitHub action instead of relying on it being installed
* Same for local machine - use a docker image instead of relying on shellcheck being there
* fix the linting errors that already existed and were uncovered by this running on more files. mostly double-quote issues.