### PR TITLE
Adds the command `leap server hostname` to print out the auto-generated hostname for the standalone installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ build-cross:
 		-ldflags "$(LDFLAGS)" \
 		.
 
+.PHONY: build-local
+build-local:
+	go build .
+
 .PHONY: docgen
 docgen:
 	rm -rf docs/*

--- a/cmd/server/hostname.go
+++ b/cmd/server/hostname.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tensorleap/helm-charts/pkg/helm"
+)
+
+func NewHostnameCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hostname",
+		Short: "Print host name",
+		Long:  "Print the unique host name generated for the standalone cluster during creation.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostname, err := helm.ReadHostname()
+			if err != nil {
+				return err
+			}
+			fmt.Println(hostname)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/server/root.go
+++ b/cmd/server/root.go
@@ -32,4 +32,5 @@ func init() {
 	RootCommand.AddCommand(server.NewStopCmd())
 	RootCommand.AddCommand(server.NewUninstallCmd())
 	RootCommand.AddCommand(server.NewToolCmd())
+	RootCommand.AddCommand(NewHostnameCmd())
 }


### PR DESCRIPTION
Relies on helm-charts PR to be committed first:
 https://github.com/tensorleap/helm-charts/pull/182

