### PR TITLE
Handle missing project background image

### DIFF
--- a/cmd/projects/publish.go
+++ b/cmd/projects/publish.go
@@ -52,7 +52,7 @@ func NewPublishCmd() *cobra.Command {
 			publishProject := func(projectEntity *project.ProjectEntity) error {
 				projectContext, err := project.BuildProjectContext(ctx, projectEntity, version)
 				if err != nil {
-					return fmt.Errorf("failed to extract project context: %v", err)
+					return err
 				}
 
 				err = hub.HandleProjectExistsOnPublish(ctx, hubApi, meta, &projectContext.Meta, override)

--- a/pkg/project/utils.go
+++ b/pkg/project/utils.go
@@ -17,10 +17,11 @@ import (
 )
 
 func BuildProjectContext(ctx context.Context, projectEntity *ProjectEntity, schemaVersion int) (*hub.ProjectContext, error) {
-	bgImageBlobUrl := ""
-	if projectEntity.BgImagePath != nil {
-		bgImageBlobUrl = fmt.Sprintf("projects/%s/%s", projectEntity.Cid, *projectEntity.BgImagePath)
+	if projectEntity.BgImagePath == nil || *projectEntity.BgImagePath == "" {
+		return nil, fmt.Errorf("project %s has no background image configured", projectEntity.Name)
 	}
+
+	bgImageBlobUrl := fmt.Sprintf("projects/%s/%s", projectEntity.Cid, *projectEntity.BgImagePath)
 	urlRes, _, err := api.ApiClient.GetDownloadSignedUrl(ctx).GetDownloadSignedUrlParams(*tensorleapapi.NewGetDownloadSignedUrlParams(bgImageBlobUrl)).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get download signed url: %v", err)

--- a/pkg/project/utils_test.go
+++ b/pkg/project/utils_test.go
@@ -1,0 +1,20 @@
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tensorleap/leap-cli/pkg/tensorleapapi"
+)
+
+func TestBuildProjectContext_NoBgImage(t *testing.T) {
+	p := &tensorleapapi.Project{
+		Cid:  "cid",
+		Name: "TestProject",
+	}
+
+	_, err := BuildProjectContext(context.Background(), p, 1)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "project TestProject has no background image configured")
+}


### PR DESCRIPTION
## Summary
- validate `BgImagePath` in `BuildProjectContext`
- surface errors from `BuildProjectContext` directly in `publish` command
- add unit test for the missing background image case

## Testing
- `go test ./...` *(fails: Forbidden when downloading modules)*

------
https://chatgpt.com/codex/tasks/task_b_684694d65ed8833399bd49997039c664