### PR TITLE
Check docker-nvidia2 driver for server install

### DIFF
--- a/cmd/server/install.go
+++ b/cmd/server/install.go
@@ -3,6 +3,8 @@ package server
 import (
 	"github.com/spf13/cobra"
 	"github.com/tensorleap/helm-charts/cmd/server"
+
+	leapdocker "github.com/tensorleap/leap-cli/pkg/docker"
 )
 
 func NewInstallCmd() *cobra.Command {
@@ -17,6 +19,7 @@ func NewInstallCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			leapdocker.CheckNvidiaRuntime()
 			err = server.RunInstallCmd(cmd, flags)
 			if err != nil {
 				return mapInstallationErr(err)

--- a/pkg/docker/nvidia.go
+++ b/pkg/docker/nvidia.go
@@ -1,0 +1,36 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/tensorleap/leap-cli/pkg/log"
+)
+
+// HasNvidiaRuntime checks if the docker daemon provides an 'nvidia' runtime.
+func HasNvidiaRuntime() (bool, error) {
+	c, err := NewClient()
+	if err != nil {
+		return false, err
+	}
+	info, err := c.Info(context.Background())
+	if err != nil {
+		return false, err
+	}
+	_, ok := info.Runtimes["nvidia"]
+	return ok, nil
+}
+
+// CheckNvidiaRuntime logs whether the nvidia runtime exists.
+func CheckNvidiaRuntime() {
+	log.Info("Checking docker-nvidia2 driver...")
+	ok, err := HasNvidiaRuntime()
+	if err != nil {
+		log.Warnf("Failed to check for docker-nvidia2 driver: %v", err)
+		return
+	}
+	if !ok {
+		log.Info("Missing docker-nvidia2 driver. Install nvidia-docker2 to enable GPU support.")
+		return
+	}
+	log.Info("docker-nvidia2 driver found")
+}


### PR DESCRIPTION
## Summary
- notify user when docker `nvidia` runtime is missing
- run check before running the helm install command

## Testing
- `go vet ./...` *(fails: forbidden access to modules)*

------
https://chatgpt.com/codex/tasks/task_b_684842ccd3a48333a5755ee163b9344f