### PR TITLE
Add concierge subcommand to leap CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      GONOSUMCHECK: github.com/tensorleap/concierge
+      GONOSUMDB: github.com/tensorleap/concierge
+      GOPRIVATE: github.com/tensorleap/concierge
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GONOSUMCHECK: github.com/tensorleap/concierge
+      GONOSUMDB: github.com/tensorleap/concierge
+      GOPRIVATE: github.com/tensorleap/concierge
     steps:
       - uses: actions/checkout@v3
 

--- a/cmd/concierge/root.go
+++ b/cmd/concierge/root.go
@@ -1,0 +1,7 @@
+package concierge
+
+import (
+	conciergeCli "github.com/tensorleap/concierge/pkg/cli"
+)
+
+var RootCommand = conciergeCli.NewRootCommand()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tensorleap/leap-cli/cmd/auth"
 	"github.com/tensorleap/leap-cli/cmd/cli"
+	"github.com/tensorleap/leap-cli/cmd/concierge"
 	"github.com/tensorleap/leap-cli/cmd/hub"
 	"github.com/tensorleap/leap-cli/cmd/projects"
 	"github.com/tensorleap/leap-cli/cmd/root_cmd"
@@ -70,6 +71,7 @@ func init() {
 	RootCommand.AddCommand(cli.RootCommand)
 	RootCommand.AddCommand(projects.RootCommand)
 	RootCommand.AddCommand(run.RootCommand)
+	RootCommand.AddCommand(concierge.RootCommand)
 	if hubPkg.IsHubEnabled() {
 		RootCommand.AddCommand(hub.RootCommand)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
-	github.com/tensorleap/concierge v0.0.0-00010101000000-000000000000
+	github.com/tensorleap/concierge v0.0.0-20260321074608-eea85c4fd40a
 	github.com/tensorleap/helm-charts v0.9.9
 	github.com/tensorleap/leap-cli/pkg/tensorleapapi v0.0.0-00010101000000-000000000000
 	google.golang.org/api v0.256.0
@@ -259,7 +259,8 @@ require (
 
 replace github.com/tensorleap/leap-cli/pkg/tensorleapapi => ./pkg/tensorleapapi
 
-replace github.com/tensorleap/concierge => ../concierge
+// for local development only
+// replace github.com/tensorleap/concierge => ../concierge
 
 // for local defelopment only
 // replace github.com/tensorleap/helm-charts => ./../helm-charts

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
+	github.com/tensorleap/concierge v0.0.0-00010101000000-000000000000
 	github.com/tensorleap/helm-charts v0.9.9
 	github.com/tensorleap/leap-cli/pkg/tensorleapapi v0.0.0-00010101000000-000000000000
 	google.golang.org/api v0.256.0
@@ -257,6 +258,8 @@ require (
 )
 
 replace github.com/tensorleap/leap-cli/pkg/tensorleapapi => ./pkg/tensorleapapi
+
+replace github.com/tensorleap/concierge => ../concierge
 
 // for local defelopment only
 // replace github.com/tensorleap/helm-charts => ./../helm-charts

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
-	github.com/tensorleap/concierge v0.0.4
+	github.com/tensorleap/concierge v0.0.5
 	github.com/tensorleap/helm-charts v0.9.9
 	github.com/tensorleap/leap-cli/pkg/tensorleapapi v0.0.0-00010101000000-000000000000
 	google.golang.org/api v0.256.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
-	github.com/tensorleap/concierge v0.0.0-20260321074608-eea85c4fd40a
+	github.com/tensorleap/concierge v0.0.4
 	github.com/tensorleap/helm-charts v0.9.9
 	github.com/tensorleap/leap-cli/pkg/tensorleapapi v0.0.0-00010101000000-000000000000
 	google.golang.org/api v0.256.0

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tensorleap/concierge v0.0.0-20260321074608-eea85c4fd40a h1:mt1rkP9Z7t7tYLmXyI/UqfV51lV0ZGG61y3WhR2xLnc=
-github.com/tensorleap/concierge v0.0.0-20260321074608-eea85c4fd40a/go.mod h1:mJdDHyotAMtjjE6XoG3sJEeRaV93SMVQ0n/0IO/9C6U=
+github.com/tensorleap/concierge v0.0.4 h1:2TBo/EzsQW3t/ZvINZcM9yzlej71gAtoSsIJ67oKccI=
+github.com/tensorleap/concierge v0.0.4/go.mod h1:mJdDHyotAMtjjE6XoG3sJEeRaV93SMVQ0n/0IO/9C6U=
 github.com/tensorleap/helm-charts v0.9.9 h1:AqoWEMWGJgYnDPrh2djXS2JEmRdqamBFyCa4Xo8VSYc=
 github.com/tensorleap/helm-charts v0.9.9/go.mod h1:gUz5AG/W1918pmRV/Vc7gv9qvoBGVi0/DDlRfFto5YI=
 github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4DzbAiAiEL3c=

--- a/go.sum
+++ b/go.sum
@@ -584,6 +584,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/tensorleap/concierge v0.0.0-20260321074608-eea85c4fd40a h1:mt1rkP9Z7t7tYLmXyI/UqfV51lV0ZGG61y3WhR2xLnc=
+github.com/tensorleap/concierge v0.0.0-20260321074608-eea85c4fd40a/go.mod h1:mJdDHyotAMtjjE6XoG3sJEeRaV93SMVQ0n/0IO/9C6U=
 github.com/tensorleap/helm-charts v0.9.9 h1:AqoWEMWGJgYnDPrh2djXS2JEmRdqamBFyCa4Xo8VSYc=
 github.com/tensorleap/helm-charts v0.9.9/go.mod h1:gUz5AG/W1918pmRV/Vc7gv9qvoBGVi0/DDlRfFto5YI=
 github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4DzbAiAiEL3c=

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tensorleap/concierge v0.0.4 h1:2TBo/EzsQW3t/ZvINZcM9yzlej71gAtoSsIJ67oKccI=
-github.com/tensorleap/concierge v0.0.4/go.mod h1:mJdDHyotAMtjjE6XoG3sJEeRaV93SMVQ0n/0IO/9C6U=
+github.com/tensorleap/concierge v0.0.5 h1:ckfoqI5z2i/J2pdvyClQ7Il6r/poztd059MofRwuCAA=
+github.com/tensorleap/concierge v0.0.5/go.mod h1:mJdDHyotAMtjjE6XoG3sJEeRaV93SMVQ0n/0IO/9C6U=
 github.com/tensorleap/helm-charts v0.9.9 h1:AqoWEMWGJgYnDPrh2djXS2JEmRdqamBFyCa4Xo8VSYc=
 github.com/tensorleap/helm-charts v0.9.9/go.mod h1:gUz5AG/W1918pmRV/Vc7gv9qvoBGVi0/DDlRfFto5YI=
 github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4DzbAiAiEL3c=


### PR DESCRIPTION
## Summary
- Integrates the concierge orchestration tool as `leap concierge` subcommand
- Adds `leap concierge run`, `leap concierge doctor`, and `leap concierge version`
- Uses local `replace` directive for `github.com/tensorleap/concierge` module

## Test plan
- [x] `go build .` succeeds
- [x] `leap concierge --help` shows available subcommands
- [x] `leap concierge run --help` shows run flags
- [ ] Verify `leap concierge run` works end-to-end in a project with concierge setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)