### PR TITLE
Handle concurrent Evaluate jobs limit on leap push --eval

### DIFF
--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -22,6 +22,45 @@ type HTTPError struct {
 	Body       string
 }
 
+// ConcurrentEvaluateLimitCode is the machine-readable code the node-server
+// returns on the structured 429 payload when the per-user concurrent
+// Evaluate/Continue-Evaluate jobs limit is reached. Mirrors the constant in
+// node-server's evaluate logic.
+const ConcurrentEvaluateLimitCode = "CONCURRENT_EVALUATE_LIMIT"
+
+// RunningEvaluateJobInfo mirrors the entries the backend sends inside
+// `runningJobs` on a CONCURRENT_EVALUATE_LIMIT error. Used by the CLI to
+// offer an interactive terminate-and-retry flow.
+type RunningEvaluateJobInfo struct {
+	JobId     string `json:"jobId"`
+	ProjectId string `json:"projectId"`
+	VersionId string `json:"versionId"`
+	StartedAt string `json:"startedAt"`
+	SubType   string `json:"subType"`
+}
+
+// ConcurrentEvaluateLimitError is returned by CheckRes when an Evaluate or
+// Continue-Evaluate request is rejected because the user is already at their
+// per-user concurrent-jobs limit. Callers can type-assert on this error to
+// offer a friendly recovery flow (terminate one of the running jobs, then
+// retry the original action).
+type ConcurrentEvaluateLimitError struct {
+	URL         string
+	Message     string
+	Limit       int
+	RunningJobs []RunningEvaluateJobInfo
+}
+
+func (e *ConcurrentEvaluateLimitError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return fmt.Sprintf(
+		"Concurrent Evaluate jobs limit reached (limit=%d, running=%d)",
+		e.Limit, len(e.RunningJobs),
+	)
+}
+
 const LEAP_SKIP_SSL_VERIFY = "LEAP_SKIP_SSL_VERIFY"
 
 var ErrAuth = errors.New("user is not currently authenticated, to authenticate - please run 'leap auth login'")
@@ -119,10 +158,43 @@ func CheckRes(response *http.Response, err error) error {
 	if err != nil {
 		body = []byte(fmt.Sprintf("Error reading response body: %s", err))
 	}
+
+	// Detect the structured concurrent-evaluate-limit error so the caller can
+	// offer a friendly recovery flow instead of dumping the raw JSON.
+	if response.StatusCode == http.StatusTooManyRequests {
+		if cle := parseConcurrentEvaluateLimitError(response.Request.URL.String(), body); cle != nil {
+			return cle
+		}
+	}
+
 	return &HTTPError{
 		URL:        response.Request.URL.String(),
 		StatusCode: response.StatusCode,
 		Body:       string(body),
+	}
+}
+
+// parseConcurrentEvaluateLimitError returns a typed error if `body` is the
+// node-server's structured CONCURRENT_EVALUATE_LIMIT payload, otherwise nil
+// (so the caller can fall back to a generic HTTPError).
+func parseConcurrentEvaluateLimitError(url string, body []byte) *ConcurrentEvaluateLimitError {
+	var parsed struct {
+		Error       string                   `json:"error"`
+		Code        string                   `json:"code"`
+		Limit       int                      `json:"limit"`
+		RunningJobs []RunningEvaluateJobInfo `json:"runningJobs"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	if parsed.Code != ConcurrentEvaluateLimitCode {
+		return nil
+	}
+	return &ConcurrentEvaluateLimitError{
+		URL:         url,
+		Message:     parsed.Error,
+		Limit:       parsed.Limit,
+		RunningJobs: parsed.RunningJobs,
 	}
 }
 

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -140,6 +140,15 @@ func CheckRes(response *http.Response, err error) error {
 				Body:       body,
 			}
 		}
+		// The auto-generated OpenAPI client returns a non-nil error for any
+		// non-2xx response (e.g. 429), so the structured-error detection has
+		// to live here, not just below in the `err == nil` branch.
+		if response != nil && response.StatusCode == http.StatusTooManyRequests {
+			body := extractBodyFromError(err)
+			if cle := parseConcurrentEvaluateLimitError(response.Request.URL.String(), []byte(body)); cle != nil {
+				return cle
+			}
+		}
 		return err
 	}
 	if IsValidStatus(response) {

--- a/pkg/model/evaluate.go
+++ b/pkg/model/evaluate.go
@@ -14,6 +14,12 @@ import (
 
 const DEFAULT_BATCH_SIZE = 1
 
+// ErrEvaluateCancelled is returned from the interactive concurrent-evaluate
+// recovery flow when the user explicitly declines to terminate any running
+// job (or aborts the prompt via Ctrl+C). It's a sentinel so RunEvaluate can
+// short-circuit to a clean exit instead of treating user intent as a failure.
+var ErrEvaluateCancelled = errors.New("evaluation cancelled by user")
+
 func GetLatestEvaluateBatchSize(ctx context.Context, projectId string) (int, error) {
 	versions, err := GetVersions(ctx, projectId)
 	if err != nil {
@@ -97,6 +103,14 @@ func RunEvaluate(ctx context.Context, projectId, versionId string, batchSize int
 		if errors.As(err, &limitErr) {
 			job, err = handleConcurrentEvaluateLimit(ctx, limitErr, callEvaluate)
 			if err != nil {
+				// User-initiated cancel (or Ctrl+C) is a deliberate choice,
+				// not a failure: log a friendly note and return nil so the
+				// parent command exits cleanly without a scary "Error:" line
+				// or a usage dump.
+				if errors.Is(err, ErrEvaluateCancelled) {
+					log.Warn("Evaluation skipped — cancelled by user.")
+					return nil
+				}
 				return err
 			}
 		} else {
@@ -142,10 +156,12 @@ func handleConcurrentEvaluateLimit(
 			Options: options,
 		}
 		if err := survey.AskOne(prompt, &selected); err != nil {
-			return nil, fmt.Errorf("evaluation cancelled: %w", err)
+			// Treat any prompt failure (most commonly Ctrl+C / InterruptErr)
+			// as a deliberate cancellation so RunEvaluate exits cleanly.
+			return nil, errors.Join(ErrEvaluateCancelled, err)
 		}
 		if selected == cancelLabel {
-			return nil, errors.New("evaluation cancelled by user")
+			return nil, ErrEvaluateCancelled
 		}
 
 		chosen := byLabel[selected]

--- a/pkg/model/evaluate.go
+++ b/pkg/model/evaluate.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -77,12 +78,123 @@ func RunEvaluate(ctx context.Context, projectId, versionId string, batchSize int
 		EvaluateExistingVersionParams: existingVersionParams,
 	}
 
+	// callEvaluate is captured so it can be re-invoked on the retry path after
+	// the user terminates one of their running evaluate jobs.
+	callEvaluate := func() (*tensorleapapi.Job, error) {
+		job, res, err := api.ApiClient.Evaluate(ctx).EvaluateParams(evaluateParams).Execute()
+		if err = api.CheckRes(res, err); err != nil {
+			return nil, err
+		}
+		return job, nil
+	}
+
 	log.Info("Starting evaluation...")
-	job, res, err := api.ApiClient.Evaluate(ctx).EvaluateParams(evaluateParams).Execute()
-	if err = api.CheckRes(res, err); err != nil {
-		return fmt.Errorf("failed to start evaluation: %w", err)
+	job, err := callEvaluate()
+	if err != nil {
+		// Special-case the structured concurrent-evaluate-limit error so the
+		// user gets a guided recovery prompt instead of a JSON dump.
+		var limitErr *api.ConcurrentEvaluateLimitError
+		if errors.As(err, &limitErr) {
+			job, err = handleConcurrentEvaluateLimit(ctx, limitErr, callEvaluate)
+			if err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("failed to start evaluation: %w", err)
+		}
 	}
 
 	log.Infof("Evaluation started with job ID: %s", job.GetCid())
 	return nil
+}
+
+// handleConcurrentEvaluateLimit interactively walks the user through
+// terminating one of their running Evaluate/Continue-Evaluate jobs and
+// retrying the original evaluate call. Returns the newly-started job on
+// success, or an error if the user cancels or termination/retry fails.
+//
+// Mirrors the web-ui's ConcurrentEvaluateLimitDialog terminate-and-retry
+// flow so users get the same recovery experience from either entry point.
+func handleConcurrentEvaluateLimit(
+	ctx context.Context,
+	initial *api.ConcurrentEvaluateLimitError,
+	callEvaluate func() (*tensorleapapi.Job, error),
+) (*tensorleapapi.Job, error) {
+	current := initial
+	for {
+		log.Warn(current.Error())
+		if len(current.RunningJobs) == 0 {
+			// Shouldn't happen — backend always sends at least one row when
+			// the limit is hit — but guard anyway.
+			return nil, errors.New(
+				"concurrent evaluate jobs limit reached, but the server " +
+					"reported no running jobs to terminate",
+			)
+		}
+
+		options, byLabel := buildEvaluateJobOptions(current.RunningJobs)
+		const cancelLabel = "Cancel — do not start this evaluation"
+		options = append(options, cancelLabel)
+
+		var selected string
+		prompt := &survey.Select{
+			Message: "Select a running Evaluate job to terminate, then this evaluation will be retried:",
+			Options: options,
+		}
+		if err := survey.AskOne(prompt, &selected); err != nil {
+			return nil, fmt.Errorf("evaluation cancelled: %w", err)
+		}
+		if selected == cancelLabel {
+			return nil, errors.New("evaluation cancelled by user")
+		}
+
+		chosen := byLabel[selected]
+		log.Infof("Terminating job %s ...", chosen.JobId)
+		if err := terminateJob(ctx, chosen.JobId); err != nil {
+			return nil, fmt.Errorf("failed to terminate job %s: %w", chosen.JobId, err)
+		}
+
+		log.Info("Retrying evaluation...")
+		job, err := callEvaluate()
+		if err == nil {
+			return job, nil
+		}
+
+		// If we're still blocked (e.g., a different job started in the
+		// meantime), loop with the fresh running-jobs list. Any other error
+		// short-circuits with the original error message.
+		var nextLimit *api.ConcurrentEvaluateLimitError
+		if errors.As(err, &nextLimit) {
+			log.Warn("Still at the concurrent-evaluate-jobs limit after termination.")
+			current = nextLimit
+			continue
+		}
+		return nil, fmt.Errorf("failed to start evaluation: %w", err)
+	}
+}
+
+func buildEvaluateJobOptions(
+	jobs []api.RunningEvaluateJobInfo,
+) ([]string, map[string]api.RunningEvaluateJobInfo) {
+	options := make([]string, 0, len(jobs))
+	byLabel := make(map[string]api.RunningEvaluateJobInfo, len(jobs))
+	for _, j := range jobs {
+		startedLabel := j.StartedAt
+		if formatted, err := api.ParseAndFormatDateToLocalTime(j.StartedAt); err == nil {
+			startedLabel = formatted
+		}
+		label := fmt.Sprintf(
+			"jobId=%s  versionId=%s  started=%s",
+			j.JobId, j.VersionId, startedLabel,
+		)
+		options = append(options, label)
+		byLabel[label] = j
+	}
+	return options, byLabel
+}
+
+func terminateJob(ctx context.Context, jobId string) error {
+	params := tensorleapapi.NewTerminateJobParams(jobId)
+	_, res, err := api.ApiClient.TerminateJob(ctx).TerminateJobParams(*params).Execute()
+	return api.CheckRes(res, err)
 }


### PR DESCRIPTION
Give \`leap push --eval\` the same recovery flow as the web-ui dialog when the backend rejects an evaluation with the new \`CONCURRENT_EVALUATE_LIMIT\` error.

- New typed \`ConcurrentEvaluateLimitError\` in \`pkg/api\`; \`CheckRes\` parses the structured 429 payload (both in the err-nil and err-non-nil branches, since the OpenAPI client returns a non-nil error for any non-2xx).
- On the limit error, \`RunEvaluate\` shows an interactive \`survey.Select\` listing the user's running Evaluate jobs (or \"Cancel\"). Picking one calls \`TerminateJob\` and re-invokes the original evaluate; the loop refreshes the list if the retry is still blocked.
- User-initiated cancellation (Cancel selection or Ctrl+C) returns \`ErrEvaluateCancelled\` and exits 0 with a friendly \"Evaluation skipped\" line — the push as a whole already succeeded.

Backend: tensorleap/node-server#1694.
UI parity: tensorleap/web-ui#3270.