### PR TITLE
Log current server version during install/upgrade/reinstall

### DIFF
--- a/cmd/server/install.go
+++ b/cmd/server/install.go
@@ -25,8 +25,7 @@ func NewInstallCmd() *cobra.Command {
 				_ = os.Setenv("TL_USE_DEFAULT_OPTION", "true")
 			}
 
-			// Best-effort: capture the current server version for analytics
-			initServerVersionForAnalytics(cmd.Context())
+			logCurrentServerVersion(cmd.Context(), "Current server version")
 
 			// Track installation started
 			startProperties := map[string]interface{}{
@@ -74,8 +73,7 @@ func NewInstallCmd() *cobra.Command {
 				return mapInstallationErr(err)
 			}
 
-			// Refresh server version after successful install
-			initServerVersionForAnalytics(cmd.Context())
+			logCurrentServerVersion(cmd.Context(), "Installed server version")
 
 			successProperties := map[string]interface{}{
 				"cli_version":     version.CliVersion,

--- a/cmd/server/reinstall.go
+++ b/cmd/server/reinstall.go
@@ -25,8 +25,7 @@ func NewReinstallCmd() *cobra.Command {
 				_ = os.Setenv("TL_USE_DEFAULT_OPTION", "true")
 			}
 
-			// Best-effort: capture the current server version for analytics
-			initServerVersionForAnalytics(cmd.Context())
+			logCurrentServerVersion(cmd.Context(), "Current server version")
 
 			startProperties := map[string]interface{}{
 				"cli_version":     version.CliVersion,
@@ -70,8 +69,7 @@ func NewReinstallCmd() *cobra.Command {
 				return mapInstallationErr(err)
 			}
 
-			// Refresh server version after successful reinstall
-			initServerVersionForAnalytics(cmd.Context())
+			logCurrentServerVersion(cmd.Context(), "Installed server version")
 
 			successProperties := map[string]interface{}{
 				"cli_version":     version.CliVersion,

--- a/cmd/server/upgrade.go
+++ b/cmd/server/upgrade.go
@@ -24,8 +24,7 @@ func NewUpgradeCmd() *cobra.Command {
 				_ = os.Setenv("TL_USE_DEFAULT_OPTION", "true")
 			}
 
-			// Best-effort: capture the current server version for analytics
-			initServerVersionForAnalytics(cmd.Context())
+			logCurrentServerVersion(cmd.Context(), "Current server version")
 
 			startProperties := map[string]interface{}{
 				"cli_version":    version.CliVersion,
@@ -61,8 +60,7 @@ func NewUpgradeCmd() *cobra.Command {
 				return mapInstallationErr(err)
 			}
 
-			// Refresh server version after successful upgrade
-			initServerVersionForAnalytics(cmd.Context())
+			logCurrentServerVersion(cmd.Context(), "Installed server version")
 
 			successProperties := map[string]interface{}{
 				"cli_version":    version.CliVersion,

--- a/cmd/server/utils.go
+++ b/cmd/server/utils.go
@@ -126,12 +126,18 @@ func getServerVersionSafe(ctx context.Context) string {
 	return v
 }
 
-// initServerVersionForAnalytics fetches the server version and sets it on
-// the analytics package so it is included in all subsequent Mixpanel events.
-func initServerVersionForAnalytics(ctx context.Context) {
-	if v := getServerVersionSafe(ctx); v != "" {
-		analytics.ServerVersion = v
+// logCurrentServerVersion fetches the installed Helm chart version, logs it
+// under the given label so users can verify which server they're operating on
+// before/after an install or upgrade, and stashes it on the analytics package
+// so it is included in subsequent Mixpanel events. No-op when no installation
+// is found (e.g. fresh install).
+func logCurrentServerVersion(ctx context.Context, label string) {
+	v := getServerVersionSafe(ctx)
+	if v == "" {
+		return
 	}
+	log.Infof("%s: %s", label, v)
+	analytics.ServerVersion = v
 }
 
 func handleLicenseAfterInstall(cmd *cobra.Command, licenseFlag *auth.LicenseFlag) error {


### PR DESCRIPTION
Surface the installed Helm chart version both before and after a server install/upgrade/reinstall, so users can verify the operation actually moved them between versions.

`initServerVersionForAnalytics` was previously silent; refactored to `logCurrentServerVersion(ctx, label)`. Analytics behavior is unchanged.

Expected output for `leap server upgrade`:

```
INFO Current server version: tensorleap-1.5.58
INFO Using data-dir: /var/lib/tensorleap/standalone
INFO Using tag: manifest-1.5.59
... (helm install runs) ...
INFO Installed server version: tensorleap-1.5.59
```

Note: `GetCurrentInsalledHelmChartVersion` upstream is k3d-specific, so on non-k3d production clusters the version lookup returns empty and no line is logged.

EN-2131