### PR TITLE
Warn user when CLI/server versions are mismatched

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tensorleap/leap-cli/cmd/run"
 	"github.com/tensorleap/leap-cli/cmd/secrets"
 	"github.com/tensorleap/leap-cli/cmd/server"
+	"github.com/tensorleap/leap-cli/pkg/api"
 	authPkg "github.com/tensorleap/leap-cli/pkg/auth"
 	"github.com/tensorleap/leap-cli/pkg/config"
 	hubPkg "github.com/tensorleap/leap-cli/pkg/hub"
@@ -79,7 +80,7 @@ func init() {
 
 func Execute() {
 	if err := RootCommand.Execute(); err != nil {
-		log.Error(err)
+		log.Error(api.HintVersionMismatch(err))
 		os.Exit(1)
 	}
 }

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -143,6 +143,45 @@ func IsValidStatus(response *http.Response) bool {
 	return response.StatusCode >= 200 && response.StatusCode < 300
 }
 
+// HintVersionMismatch returns err unchanged unless its shape suggests a
+// CLI/server version mismatch, in which case it wraps err with an actionable
+// hint telling the user to upgrade the server or the CLI. The detection is
+// duck-typed on the error string so it works for both *HTTPError and
+// *tensorleapapi.GenericOpenAPIError without coupling to the generated code.
+func HintVersionMismatch(err error) error {
+	if err == nil || !looksLikeVersionMismatch(err) {
+		return err
+	}
+	return fmt.Errorf(
+		"%w\n\nThis may indicate a CLI/server version mismatch. "+
+			"Run 'leap server upgrade' on the server host to upgrade the server, "+
+			"or 'leap cli upgrade -s | bash' to upgrade the CLI.",
+		err,
+	)
+}
+
+func looksLikeVersionMismatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "404 Not Found") || strings.Contains(msg, "405 Method Not Allowed") {
+		return true
+	}
+	// OpenAPI client emits this when a response is missing a required field —
+	// the typical shape of a server-too-old response decode failure.
+	if strings.Contains(msg, "no value given for required property") {
+		return true
+	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusMethodNotAllowed {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	http.DefaultClient = NewDefaultClient()
 }

--- a/pkg/api/version_hint_test.go
+++ b/pkg/api/version_hint_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHintVersionMismatch_PassThroughUnrelated(t *testing.T) {
+	in := errors.New("disk is on fire")
+	got := HintVersionMismatch(in)
+	if got != in {
+		t.Fatalf("expected unrelated error to pass through unchanged, got %q", got)
+	}
+}
+
+func TestHintVersionMismatch_Nil(t *testing.T) {
+	if HintVersionMismatch(nil) != nil {
+		t.Fatalf("expected nil to pass through")
+	}
+}
+
+func TestHintVersionMismatch_Detects(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"404 raw status", errors.New("404 Not Found")},
+		{"405 raw status", errors.New("405 Method Not Allowed")},
+		{"openapi decode missing property", errors.New("no value given for required property foo")},
+		{"HTTPError with 404", &HTTPError{StatusCode: http.StatusNotFound, URL: "/x"}},
+		{"HTTPError with 405", &HTTPError{StatusCode: http.StatusMethodNotAllowed, URL: "/x"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HintVersionMismatch(tc.err)
+			if got == nil {
+				t.Fatalf("expected wrapped error, got nil")
+			}
+			if !strings.Contains(got.Error(), "leap server upgrade") {
+				t.Fatalf("expected hint to mention 'leap server upgrade', got: %s", got)
+			}
+			// Wrapped error chain must still unwrap to the original cause.
+			if !errors.Is(got, tc.err) {
+				t.Fatalf("errors.Is failed: wrapped does not chain back to original cause")
+			}
+		})
+	}
+}
+
+func TestHintVersionMismatch_DoesNotMatch200LikeError(t *testing.T) {
+	in := &HTTPError{StatusCode: http.StatusInternalServerError, URL: "/x"}
+	got := HintVersionMismatch(in)
+	if got != in {
+		t.Fatalf("expected 500 error to pass through unchanged, got %q", got)
+	}
+}

--- a/pkg/auth/utils.go
+++ b/pkg/auth/utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tensorleap/leap-cli/pkg/config"
 	"github.com/tensorleap/leap-cli/pkg/log"
 	"github.com/tensorleap/leap-cli/pkg/tensorleapapi"
+	"github.com/tensorleap/leap-cli/pkg/version"
 )
 
 var ErrNotLoggedIn = fmt.Errorf("not logged in")
@@ -155,6 +156,7 @@ func RequireAuth(ctx context.Context) (context.Context, *tensorleapapi.UserData,
 		authCtx := env.AuthContext(ctx)
 		userData, err := GetWhoami(authCtx)
 		if err == nil {
+			version.CheckServerCompatibility(authCtx)
 			return authCtx, userData, nil
 		}
 		log.Warnf("Current authentication is invalid or expired: %v", err)
@@ -234,6 +236,8 @@ func InteractiveLogin(ctx context.Context) (context.Context, *tensorleapapi.User
 	if err != nil {
 		return ctx, nil, fmt.Errorf("login verification failed: %v", err)
 	}
+
+	version.CheckServerCompatibility(authCtx)
 
 	fmt.Printf("Logged in as: %s (%s)\n", userData.Local.Email, userData.TeamName)
 

--- a/pkg/version/compat.go
+++ b/pkg/version/compat.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tensorleap/leap-cli/pkg/api"
+	"github.com/tensorleap/leap-cli/pkg/log"
+)
+
+// MinServerSchemaVersion is the lowest server schema version this CLI build is
+// compatible with. Bump it together with any CLI change that depends on server
+// behavior that isn't available on older servers. The value is compared to
+// GetEnvironmentInfo.schemaVersion at runtime.
+const MinServerSchemaVersion = 1
+
+// CheckServerCompatibility probes the connected server and logs a warning if
+// its schema version is older than what this CLI requires. It is intentionally
+// best-effort: any failure to reach the server or interpret the response is
+// swallowed so the user's actual command can proceed and surface its own error.
+func CheckServerCompatibility(ctx context.Context) {
+	envInfo, _, err := api.ApiClient.GetEnvironmentInfo(ctx).Execute()
+	if err != nil || envInfo == nil {
+		return
+	}
+	if msg := serverUpgradeWarning(int(envInfo.SchemaVersion), MinServerSchemaVersion); msg != "" {
+		log.Warn(msg)
+	}
+}
+
+// serverUpgradeWarning returns a user-facing warning when the server schema is
+// below the required minimum. Returns "" when the server is compatible.
+func serverUpgradeWarning(serverSchema, minRequired int) string {
+	if serverSchema >= minRequired {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Your Tensorleap server (schema v%d) is older than this CLI requires (>= v%d). "+
+			"Commands may fail due to a version mismatch. "+
+			"To upgrade the server, run 'leap server upgrade' on the server host.",
+		serverSchema, minRequired,
+	)
+}

--- a/pkg/version/compat_test.go
+++ b/pkg/version/compat_test.go
@@ -1,0 +1,58 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestServerUpgradeWarning(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverSchema  int
+		minRequired   int
+		wantEmpty     bool
+		wantSubstring string
+	}{
+		{
+			name:         "compatible (equal)",
+			serverSchema: 5,
+			minRequired:  5,
+			wantEmpty:    true,
+		},
+		{
+			name:         "compatible (newer)",
+			serverSchema: 7,
+			minRequired:  5,
+			wantEmpty:    true,
+		},
+		{
+			name:          "incompatible (older)",
+			serverSchema:  3,
+			minRequired:   5,
+			wantSubstring: "leap server upgrade",
+		},
+		{
+			name:          "incompatible mentions both versions",
+			serverSchema:  2,
+			minRequired:   10,
+			wantSubstring: "schema v2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := serverUpgradeWarning(tc.serverSchema, tc.minRequired)
+			if tc.wantEmpty {
+				if got != "" {
+					t.Fatalf("expected empty warning, got %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("expected non-empty warning for server=%d min=%d", tc.serverSchema, tc.minRequired)
+			}
+			if tc.wantSubstring != "" && !strings.Contains(got, tc.wantSubstring) {
+				t.Fatalf("warning %q missing expected substring %q", got, tc.wantSubstring)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two complementary nudges so users know to run `leap server upgrade` (or `leap cli upgrade`) when the CLI breaks against an older server.

**Proactive probe** (commit 1) — after authentication, query `GetEnvironmentInfo` and warn if `schemaVersion < MinServerSchemaVersion`. The check is best-effort: any failure to reach the server is swallowed so the user's actual command can still run.

**Reactive hint** (commit 2) — wrap the top-level CLI error with an "upgrade server / upgrade CLI" suffix when the error shape matches a known mismatch: a 404/405 on an endpoint, or the OpenAPI decode error emitted when a response is missing a required field. Catches cases the probe doesn't cover (e.g. server passes the probe but a specific endpoint shape drifted).

### Notes before merging

- **`MinServerSchemaVersion` is set to `1`** as a placeholder so no user sees the proactive warning today. Bump it in the same change as a CLI release that depends on newer server behavior.
- `schemaVersion` from `GetEnvironmentInfo` is the project-schema field used by the hub today. If it doesn't move on every breaking API change, the proactive probe is a no-op for those cases — the reactive hint is the safety net.
- The reactive hint is heuristic. Worst case is noise on legitimate 404s (e.g. a missing project on a path-param GET). Most API endpoints are POST so the false-positive surface is small.

EN-1889