### PR TITLE
Show project and version names in concurrent-evaluate prompt

### DIFF
--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -32,11 +32,13 @@ const ConcurrentEvaluateLimitCode = "CONCURRENT_EVALUATE_LIMIT"
 // `runningJobs` on a CONCURRENT_EVALUATE_LIMIT error. Used by the CLI to
 // offer an interactive terminate-and-retry flow.
 type RunningEvaluateJobInfo struct {
-	JobId     string `json:"jobId"`
-	ProjectId string `json:"projectId"`
-	VersionId string `json:"versionId"`
-	StartedAt string `json:"startedAt"`
-	SubType   string `json:"subType"`
+	JobId       string `json:"jobId"`
+	ProjectId   string `json:"projectId"`
+	ProjectName string `json:"projectName,omitempty"`
+	VersionId   string `json:"versionId"`
+	VersionName string `json:"versionName,omitempty"`
+	StartedAt   string `json:"startedAt"`
+	SubType     string `json:"subType"`
 }
 
 // ConcurrentEvaluateLimitError is returned by CheckRes when an Evaluate or

--- a/pkg/model/evaluate.go
+++ b/pkg/model/evaluate.go
@@ -199,9 +199,21 @@ func buildEvaluateJobOptions(
 		if formatted, err := api.ParseAndFormatDateToLocalTime(j.StartedAt); err == nil {
 			startedLabel = formatted
 		}
+		// Prefer human-readable names that the backend resolves for us;
+		// fall back to the raw ObjectIds when the server didn't (or couldn't)
+		// provide a name. The disambiguating jobId stays at the end so two
+		// identically-named jobs are still distinguishable.
+		projectLabel := j.ProjectName
+		if projectLabel == "" {
+			projectLabel = j.ProjectId
+		}
+		versionLabel := j.VersionName
+		if versionLabel == "" {
+			versionLabel = j.VersionId
+		}
 		label := fmt.Sprintf(
-			"jobId=%s  versionId=%s  started=%s",
-			j.JobId, j.VersionId, startedLabel,
+			"%s  ·  %s  ·  started=%s  ·  jobId=%s",
+			projectLabel, versionLabel, startedLabel, j.JobId,
 		)
 		options = append(options, label)
 		byLabel[label] = j


### PR DESCRIPTION
Follow-up to #235. The interactive terminate-and-retry prompt was showing raw ObjectIds, which is unreadable in a terminal:
\`\`\`
jobId=6a0595864a3a21d643a81f14  versionId=6a01a133d58f4f63578fed02  started=...
\`\`\`
Now it shows project + version names that the backend resolves and includes in the new \`CONCURRENT_EVALUATE_LIMIT\` payload (\`projectName\`, \`versionName\` on \`RunningEvaluateJobInfo\`), falling back to the IDs if the server didn't supply them. The disambiguating \`jobId\` is kept at the end so two identically-named jobs are still distinguishable.

Requires the matching node-server change (tensorleap/node-server#1694) to be deployed; without it the labels gracefully fall back to the existing ID-based format.