### PR TITLE
Bump helm-charts to v0.10.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
-	github.com/tensorleap/helm-charts v0.10.3
+	github.com/tensorleap/helm-charts v0.10.4
 	github.com/tensorleap/leap-cli/pkg/tensorleapapi v0.0.0-00010101000000-000000000000
 	google.golang.org/api v0.256.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tensorleap/helm-charts v0.10.3 h1:BtRBNbxA3jwIbpYLEJc3KP9s232kxRIAAMkqX9GsHvw=
-github.com/tensorleap/helm-charts v0.10.3/go.mod h1:btxOnI4CfbZ+7gVfN7T0i3DKy4H80HnkJB5EAULuRHs=
+github.com/tensorleap/helm-charts v0.10.4 h1:G9pcDuFCvAhWTYLg6n3+NyYWUmO+e+rv5k5zYrb5i+4=
+github.com/tensorleap/helm-charts v0.10.4/go.mod h1:btxOnI4CfbZ+7gVfN7T0i3DKy4H80HnkJB5EAULuRHs=
 github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4DzbAiAiEL3c=
 github.com/theupdateframework/notary v0.7.0/go.mod h1:c9DRxcmhHmVLDay4/2fUYdISnHqbFDGRSlXPO0AhYWw=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=


### PR DESCRIPTION
Picks up [helm-charts#379](https://github.com/tensorleap/helm-charts/pull/379), which flips the `leap server upgrade` "use latest version" prompt default from No (y/N) to Yes (Y/n) and makes `-y` actually upgrade instead of keeping the current tag.

EN-2254