### PR TITLE
Versions list: fix V/✔ shown for terminated combined-push jobs

### DIFF
--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -346,7 +346,12 @@ func FormatVersionDisplayName(version *tensorleapapi.SlimVersion, status Version
 }
 
 func GetRunsStatusesPerVersionId(ctx context.Context, projectId string) (map[string][]tensorleapapi.RunProcess, error) {
+	// Pushes after the code-parse + import-model merger run under a single
+	// JOBSUBTYPE_PUSH; older versions still have the two split jobs. Include
+	// all three so CalcVersionStatus can see a terminated push regardless of
+	// which job shape produced it.
 	subTypes := []tensorleapapi.JobSubType{
+		tensorleapapi.JOBSUBTYPE_PUSH,
 		tensorleapapi.JOBSUBTYPE_IMPORT_MODEL,
 		tensorleapapi.JOBSUBTYPE_CODE_PARSE,
 	}


### PR DESCRIPTION
## Summary

The version selector in the CLI was rendering a green ✔ next to versions whose push job had been terminated (e.g. user hits Ctrl-C at step 3 of the Push pipeline after the model record has already been written).

Root cause: [`GetRunsStatusesPerVersionId`](https://github.com/tensorleap/leap-cli/blob/fix-terminated-push-v-state/pkg/model/utils.go#L348) only queries the legacy split push subtypes:

```go
subTypes := []tensorleapapi.JobSubType{
    tensorleapapi.JOBSUBTYPE_IMPORT_MODEL,
    tensorleapapi.JOBSUBTYPE_CODE_PARSE,
}
```

Pushes after the code-parse + import-model merger run as a single `JOBSUBTYPE_PUSH` job. The call returns an empty list for those versions, `CalcVersionStatus`'s `for _, job := range lastJobByType` loop runs zero iterations, and the function falls through to `VersionStatus_FINISHED` whenever `hasModel` is true — exactly the "terminated at step 3" case the user reported.

Fix: add `JOBSUBTYPE_PUSH` to the subtype filter. The classifier now sees the terminated combined-push job, `IsJobFailed` matches (`Terminated`/`Stopped`/`Failed`), and the version renders ✖.

## Cases covered

| Push subtype shape | Terminated when? | `hasModel` | Before | After |
|---|---|---|---|---|
| combined `Push` | early (no model yet) | false | ✖ (via `!hasModel`) | ✖ |
| combined `Push` | late (model written) | true | **✔ (bug)** | **✖** |
| legacy `Code Parse` + `Import Model` | any | either | ✖ | ✖ (unchanged) |
| any subtype | finished cleanly | true | ✔ | ✔ (unchanged) |

## Test plan
- [ ] Push a version on a project running the new combined-push engine, terminate it mid-pipeline, open the version selector → row shows ✖
- [ ] Push a version on a project still emitting the legacy split jobs, terminate it → row still shows ✖ (regression check)
- [ ] Push a version that finishes cleanly → row still shows ✔