### PR TITLE
Honor proxy env in overridden default HTTP client

### DIFF
--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -120,7 +120,11 @@ func NewDefaultClient() *http.Client {
 	customHttpClient := &http.Client{}
 
 	roundTripper := &CustomRoundTripper{
-		originalRoundTripper: http.Transport{},
+		// Replaces the global http.DefaultClient, so it must keep honoring
+		// HTTP(S)_PROXY/NO_PROXY the way the stock http.DefaultTransport does.
+		originalRoundTripper: http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 	}
 	customHttpClient.Transport = roundTripper
 


### PR DESCRIPTION
## What

Restore proxy support on the HTTP client that replaces the global `http.DefaultClient`.

`pkg/api/utils.go` runs an `init()` that swaps `http.DefaultClient` for one built around a bare `http.Transport{}`. A bare transport has `Proxy: nil`, whereas the stock `http.DefaultTransport` sets `Proxy: http.ProxyFromEnvironment`. The override therefore disabled `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` handling **process-wide** — including for the `http.Get` calls in the embedded `helm-charts` code (e.g. `pkg/github` release lookups and chart downloads).

The fix sets `Proxy: http.ProxyFromEnvironment` on the replacement transport.

## Why

On a proxied/offline host, `leap server install` failed with:

```
Get "https://api.github.com/repos/tensorleap/helm-charts/releases?...": dial tcp: lookup api.github.com on 127.0.0.53:53: no such host
```

even with the correct `HTTPS_PROXY` exported. The transport never consulted the proxy env, so it resolved `api.github.com` directly (no direct internet) and failed. This blocked online-mode installs behind a corporate proxy.

## Reviewer notes

- One-line behavioral change; no exported signatures touched.
- `CustomRoundTripper`'s 401→`ErrAuth` behavior is unchanged.
- `go build ./...` and `go vet ./pkg/api/` pass.
- Hosts running an older `leap` binary need a rebuild to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)