### PR TITLE
Honor HTTP(S)_PROXY in the default HTTP client

### DIFF
--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -120,7 +120,12 @@ func NewDefaultClient() *http.Client {
 	customHttpClient := &http.Client{}
 
 	roundTripper := &CustomRoundTripper{
-		originalRoundTripper: http.Transport{},
+		originalRoundTripper: http.Transport{
+			// Honor HTTP_PROXY/HTTPS_PROXY/NO_PROXY. Without this, the init()
+			// below replaces http.DefaultClient with a proxy-less transport,
+			// breaking every http.Get in the binary behind a corporate proxy.
+			Proxy: http.ProxyFromEnvironment,
+		},
 	}
 	customHttpClient.Transport = roundTripper
 


### PR DESCRIPTION
## Problem

`init()` in `pkg/api/utils.go` replaces Go's global `http.DefaultClient` with a client built on a bare `http.Transport{}` (no `Proxy` set). Every `http.Get` in the binary — including the bundled helm-charts installer's `GetReleasesPage` — therefore silently ignores `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`.

Behind a corporate proxy (no direct internet egress), `leap server install` fails with:

```
Get "https://api.github.com/repos/tensorleap/helm-charts/releases?page=1&per_page=100":
dial tcp: lookup api.github.com on 127.0.0.53:53: no such host
```

even when the proxy env vars are set correctly. Confirmed root cause: `curl` using the exact same env reaches GitHub (200), while `leap` does a **direct** DNS lookup — because its `http.DefaultClient` has no proxy.

## Fix

Set `Proxy: http.ProxyFromEnvironment` on the transport in `NewDefaultClient()`. This restores standard proxy support for the whole binary.

It also clears the misleading `No internet connection found` warning, since `hasInternet()` (`cmd/server/utils.go`) uses the same client.

## Testing

Built for linux/amd64 and verified on a customer host behind an authenticated Squid proxy: the GitHub release lookup now succeeds through the proxy, and the install proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
