### PR TITLE
push: route update_metadata through update-evaluate (no full re-eval)

### DIFF
--- a/cmd/root_cmd/push.go
+++ b/cmd/root_cmd/push.go
@@ -106,7 +106,7 @@ Examples:
 	cmd.Flags().StringVarP(&in.overwriteVersionRef, "overwrite", "o", "", "Overwrite an existing version (id, or name — picker shown if name is ambiguous)")
 	cmd.Flags().StringVar(&in.overwriteVersionRef, "overwrite-version", "", "")
 	_ = cmd.Flags().MarkDeprecated("overwrite-version", "use --overwrite (-o) instead")
-	cmd.Flags().StringSliceVarP(&in.updateParts, "update", "u", nil, "What changed in the code on overwrite (repeatable; implies --eval; skips the prompt). Values: metadata, metric, metric_config, visualization (viz). metadata+metric trigger a full re-evaluation.")
+	cmd.Flags().StringSliceVarP(&in.updateParts, "update", "u", nil, "What changed in the code on overwrite (repeatable; implies --eval; skips the prompt). Values: metadata, metric, metric_config, visualization (viz). metric triggers a full re-evaluation.")
 	cmd.Flags().BoolVar(&in.noVisualization, "novis", false, "Skip the visualize_samples step on the subsequent evaluate (requires --eval / -u)")
 	cmd.Flags().BoolVar(&in.yes, "yes", false, "Acknowledge pre-push warnings and proceed without prompting")
 	return cmd

--- a/pkg/model/evaluate.go
+++ b/pkg/model/evaluate.go
@@ -149,7 +149,7 @@ var changeOptions = []changeOption{
 	{
 		key:    ChangeMetadata,
 		label:  "Metadata",
-		hint:   "full re-eval",
+		hint:   "add new metadata",
 		action: tensorleapapi.UPDATEACTION_UPDATE_METADATA,
 	},
 	{
@@ -172,8 +172,7 @@ var changeOptions = []changeOption{
 }
 
 func triggersFullReeval(a tensorleapapi.UpdateAction) bool {
-	return a == tensorleapapi.UPDATEACTION_UPDATE_METADATA ||
-		a == tensorleapapi.UPDATEACTION_UPDATE_METRIC
+	return a == tensorleapapi.UPDATEACTION_UPDATE_METRIC
 }
 
 func PlanFromUpdateActions(actions []tensorleapapi.UpdateAction) EvaluatePlan {


### PR DESCRIPTION
## What

When a user selects **Metadata** as what changed (interactive prompt or `--update metadata`), `leap push` now routes it through **update-evaluate** (`UpdateEvaluateArtifact` with the `update_metadata` action) instead of triggering a full re-evaluation.

Pairs with engine [#2384](https://github.com/tensorleap/engine/pull/2384) and node-server [#1766](https://github.com/tensorleap/node-server/pull/1766). The engine writes a new PCA-scoped metadata revision and pins it; no model re-run is needed.

## Changes (`pkg/model/evaluate.go`, `cmd/root_cmd/push.go`)

- `triggersFullReeval()` no longer treats `UPDATE_METADATA` as a reset trigger — only `UPDATE_METRIC` (still unsupported by the engine) forces a full re-eval. Metadata now resolves to `EvaluatePlanUpdate` → `RunUpdateEvaluateArtifact`, which calls the `updateEvaluateArtifact` endpoint with `updateActions: [update_metadata]`.
- Fixed the now-wrong "full re-eval" hint on the **Metadata** prompt option and the `--update` flag help text.

The generated `pkg/tensorleapapi/` client already exposes `UpdateEvaluateArtifact` and `UPDATEACTION_UPDATE_METADATA`, so **no client regeneration** was needed.

## Testing
`go build ./...` clean. (No existing tests cover the plan-selection logic.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
