### PR TITLE
Bump push-job timeout from 60 to 90 minutes

### DIFF
--- a/pkg/model/api.go
+++ b/pkg/model/api.go
@@ -189,7 +189,7 @@ func WaitForPushJob(ctx context.Context, projectId, versionId, jobId string) err
 	return nil
 }
 
-const TIMEOUT_FOR_IMPORT_MODEL_JOB = 60 * time.Minute
+const TIMEOUT_FOR_IMPORT_MODEL_JOB = 90 * time.Minute
 
 var ErrJobFailed = fmt.Errorf("import model job failed")
 


### PR DESCRIPTION
## What

Raise the push-job timeout (`TIMEOUT_FOR_IMPORT_MODEL_JOB`) from 60 to 90 minutes in `pkg/model/api.go`.

## Why

`leap push` waits on the combined push job (code parse + model import) via `WaitForPushJob`, which uses this constant as a **no-progress** timeout (the timer resets only when the job's reported steps change). Slow code-parse / model-import phases that emit no incremental progress could trip the 60-minute cap despite the job still running on the server. 90 minutes gives more headroom.

## Notes

- Build passes (`go build ./...`).
- This is purely a constant bump; no behavior change beyond the longer window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)