### PR TITLE
Make push/select usable headless: select by id, TTY-guard error viewer, fix model-type warning

### DIFF
--- a/cmd/projects/select.go
+++ b/cmd/projects/select.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tensorleap/leap-cli/pkg/code"
+	"github.com/tensorleap/leap-cli/pkg/entity"
 	"github.com/tensorleap/leap-cli/pkg/log"
 	"github.com/tensorleap/leap-cli/pkg/project"
 	"github.com/tensorleap/leap-cli/pkg/secret"
@@ -34,11 +35,29 @@ Pass a project id as an argument to select it non-interactively (no prompts):
 				projectId = args[0]
 			}
 
-			// With a projectId arg this resolves the project by id without
-			// prompting; without one it falls back to the interactive picker.
-			selectedProject, projectWasCreated, err := project.GetProjectFromProjectId(ctx, projectId, true)
-			if err != nil {
-				return fmt.Errorf("failed to select or create project: %w", err)
+			var selectedProject *project.ProjectEntity
+			projectWasCreated := false
+			if projectId != "" {
+				// Explicit id: resolve it directly and fail if it's unknown, so a
+				// headless `select <id>` reports a bad id instead of silently
+				// dropping into the interactive picker.
+				projects, listErr := project.GetProjects(ctx)
+				if listErr != nil {
+					return fmt.Errorf("failed to get projects: %w", listErr)
+				}
+				found, findErr := entity.GetEntityById(projectId, projects, project.ProjectEntityDesc)
+				if findErr != nil {
+					return fmt.Errorf("project with id %q not found", projectId)
+				}
+				selectedProject = found
+			} else {
+				// No arg: interactive create-or-select picker.
+				sp, wasCreated, selErr := project.GetProjectFromProjectId(ctx, "", true)
+				if selErr != nil {
+					return fmt.Errorf("failed to select or create project: %w", selErr)
+				}
+				selectedProject = sp
+				projectWasCreated = wasCreated
 			}
 
 			if workspaceConfig.SecretId != "" {

--- a/cmd/projects/select.go
+++ b/cmd/projects/select.go
@@ -14,9 +14,13 @@ import (
 func NewSelectCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:   "select",
+		Use:   "select [projectId]",
 		Short: "Select project and code integration",
-		Long:  `Select a project and code integration to work with. This will update the workspace configuration.`,
+		Long: `Select a project and code integration to work with. This will update the workspace configuration.
+
+Pass a project id as an argument to select it non-interactively (no prompts):
+  leap projects select 6a3c2eb0b186171463d36eb6`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -25,11 +29,14 @@ func NewSelectCmd() *cobra.Command {
 				return fmt.Errorf("failed to load workspace config: %w", err)
 			}
 
-			projects, err := project.GetProjects(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to get projects: %w", err)
+			projectId := ""
+			if len(args) > 0 {
+				projectId = args[0]
 			}
-			selectedProject, projectWasCreated, err := project.SelectOrCreateProject(ctx, projects, true)
+
+			// With a projectId arg this resolves the project by id without
+			// prompting; without one it falls back to the interactive picker.
+			selectedProject, projectWasCreated, err := project.GetProjectFromProjectId(ctx, projectId, true)
 			if err != nil {
 				return fmt.Errorf("failed to select or create project: %w", err)
 			}
@@ -53,18 +60,22 @@ func NewSelectCmd() *cobra.Command {
 
 			workspaceConfig.ProjectId = selectedProject.GetCid()
 
-			baseImages, defaultVersionId, err := code.GetPythonVersions(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to get python versions: %w", err)
-			}
+			// When a project id is passed explicitly, keep the flow non-interactive:
+			// preserve the workspace's existing python version instead of prompting.
+			if projectId == "" {
+				baseImages, defaultVersionId, err := code.GetPythonVersions(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get python versions: %w", err)
+				}
 
-			if workspaceConfig.PythonVersion != "" {
-				defaultVersionId = workspaceConfig.PythonVersion
-			}
+				if workspaceConfig.PythonVersion != "" {
+					defaultVersionId = workspaceConfig.PythonVersion
+				}
 
-			workspaceConfig.PythonVersion, err = code.AskForPythonVersion(defaultVersionId, baseImages)
-			if err != nil {
-				return fmt.Errorf("failed to sync python version: %w", err)
+				workspaceConfig.PythonVersion, err = code.AskForPythonVersion(defaultVersionId, baseImages)
+				if err != nil {
+					return fmt.Errorf("failed to sync python version: %w", err)
+				}
 			}
 
 			err = workspace.SetWorkspaceConfig(workspaceConfig, ".")

--- a/pkg/interactive_pages/interactive_pages.go
+++ b/pkg/interactive_pages/interactive_pages.go
@@ -9,6 +9,7 @@ import (
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
 )
 
 const (
@@ -763,6 +764,13 @@ type ReportPages = TabbedReport
 type InteractivePage = Page
 
 func confirmInteractiveView() bool {
+	// Without an interactive terminal (headless / piped / CI runs) there is no
+	// one to answer the prompt and no TTY to draw the interactive TUI on. Skip
+	// it and let the caller print the report plainly instead of hanging or
+	// crashing on an alt-screen program with no terminal.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return false
+	}
 	fmt.Print("View errors in interactive mode? (Y/n): ")
 	reader := bufio.NewReader(os.Stdin)
 	input, err := reader.ReadString('\n')

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -60,7 +60,7 @@ func SelectModelType(modelType *string, modelPath string) error {
 
 	ext := strings.ToLower(filepath.Ext(modelPath))
 
-	if len(*modelType) > 0 && slices.Contains(MODEL_TYPES, *modelType) {
+	if len(*modelType) > 0 && !slices.Contains(MODEL_TYPES, *modelType) {
 		log.Warn(fmt.Sprintf("Model type %s not supported. Supported types are: %s", *modelType, MODEL_TYPES))
 	}
 


### PR DESCRIPTION
Three small, independent fixes that broke autonomous (non-interactive) `leap push` runs. Each is low-risk and preserves existing interactive behavior.

## 1. `projects select [projectId]` — non-interactive select by id
`select` had no id form: its `RunE` always went through the interactive picker (`SelectOrCreateProject`) plus an interactive python-version prompt, so headless callers dead-ended and had to hand-edit `leap.yaml`. Now an optional `projectId` arg resolves the project via `GetProjectFromProjectId` (same helper `init --projectId` uses) and skips the python prompt on that path. No arg → unchanged interactive flow.

```
leap projects select 6a3c2eb0b186171463d36eb6
```

## 2. TTY guard on the failed-parse error viewer
`interactive_pages.confirmInteractiveView` printed `View errors in interactive mode? (Y/n):`, read stdin, and on read error (EOF) **defaulted to `true`**, launching a bubbletea alt-screen TUI. In a headless run a failed `push` hit EOF → launched a TUI with no terminal → crashed the process (exit 1) even when the build/parse job had actually been created. Added the same `term.IsTerminal(os.Stdin.Fd())` guard already used in `push.go`; headless now falls through to `PrintOnly(report)`.

## 3. Fix inverted model-type warning
`model.SelectModelType` warned `Model type X not supported` when `slices.Contains(MODEL_TYPES, X)` was **true** — i.e. precisely when the type *was* supported (missing `!`). The bogus warning fired on every `--type ONNX` / `--type H5_TF2` push and misled autonomous agents into thinking the model was rejected.

## Testing
Built locally via `make dev` and exercised against a local server (mnist project): non-interactive `projects select <id>`, a headless `push` that prints parse errors plainly instead of crashing, and `--type ONNX` with no false warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)