### PR TITLE
Upgrade helm-charts installer to v0.10.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
-	github.com/tensorleap/helm-charts v0.10.10
+	github.com/tensorleap/helm-charts v0.10.13
 	github.com/tensorleap/leap-cli/pkg/tensorleapapi v0.0.0-00010101000000-000000000000
 	google.golang.org/api v0.256.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tensorleap/helm-charts v0.10.10 h1:TcboorX7pFYzwUzvGqAiGijqgK+f0oWRWan9ppKiiTI=
-github.com/tensorleap/helm-charts v0.10.10/go.mod h1:btxOnI4CfbZ+7gVfN7T0i3DKy4H80HnkJB5EAULuRHs=
+github.com/tensorleap/helm-charts v0.10.13 h1:yYo6V5Q9BM4setBA/DlLWnN2LBFmiogf+gMuTiOnUlM=
+github.com/tensorleap/helm-charts v0.10.13/go.mod h1:btxOnI4CfbZ+7gVfN7T0i3DKy4H80HnkJB5EAULuRHs=
 github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4DzbAiAiEL3c=
 github.com/theupdateframework/notary v0.7.0/go.mod h1:c9DRxcmhHmVLDay4/2fUYdISnHqbFDGRSlXPO0AhYWw=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=


### PR DESCRIPTION
## What

Bumps `github.com/tensorleap/helm-charts` v0.10.10 → **v0.10.13** (`go get` + `go mod tidy`; `make fmt` clean, full test suite green).

## What the new installer brings (v0.10.10 → v0.10.13)

**Multi-user / mixed-operator fixes (BF-1092 context):**
- Shared-dir permission self-heal: existing 0755 dirs left by a previous operator are healed to world-writable, with sudo allowed only for paths resolving inside the Tensorleap data dir — a second sudo-capable user (e.g. `ssm-user` over an `ubuntu` install) can now upgrade/reinstall without purging (#407, #410)
- Shared kubeconfig written into the data dir (`manifests/kubeconfig.yaml`) + `/etc/profile.d` drop-in on Linux, so every local user's `kubectl`/`helm` works (see MULTI-USER.md)

**Other:**
- Blob-mode payload store and per-job shared volumes (#402)
- Datadog log-volume reduction (#396), RabbitMQ CPU request, image tag updates

## Release plan

After this merges, `v0.0.157` will be tagged on the master merge commit to trigger the CLI release build.