### PR TITLE
push: survive no-progress stalls while the job still runs; drop redundant overwrite note

### DIFF
--- a/cmd/root_cmd/push.go
+++ b/cmd/root_cmd/push.go
@@ -329,7 +329,7 @@ func (s *pushState) resolveOverwriteTarget() error {
 			return fmt.Errorf("version %q has no model; set --model-path (-m)", in.overwriteVersionRef)
 		}
 	} else if in.modelPath == "" {
-		isOverwrite, info, chosenPath, err := model.AskUserForModelPathOrOverwrite(s.ctx, s.projectId(), &in.modelVersionName, in.runEval)
+		isOverwrite, info, chosenPath, err := model.AskUserForModelPathOrOverwrite(s.ctx, s.projectId(), &in.modelVersionName)
 		if err != nil {
 			return err
 		}

--- a/pkg/model/api.go
+++ b/pkg/model/api.go
@@ -191,6 +191,13 @@ func WaitForPushJob(ctx context.Context, projectId, versionId, jobId string) err
 
 const TIMEOUT_FOR_IMPORT_MODEL_JOB = 60 * time.Minute
 
+// maxWaitForImportModelJob caps the total wait across no-progress retries.
+// Var (not const) so tests can shrink it.
+var maxWaitForImportModelJob = 6 * time.Hour
+
+// waitForSteps is a seam for tests to stub the underlying step-waiter.
+var waitForSteps = api.WaitForConditionWithSteps
+
 var ErrJobFailed = fmt.Errorf("import model job failed")
 
 var ErrImportModelTimeout = fmt.Errorf("timeout occurred while waiting for import model job status")
@@ -215,7 +222,20 @@ func waitForImportModelJob(ctx context.Context, projectId, importModelJobId, res
 		return false, steps, nil
 	}
 
-	err = api.WaitForConditionWithSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_IMPORT_MODEL_JOB)
+	// TIMEOUT_FOR_IMPORT_MODEL_JOB is a no-progress window, not a total cap: the
+	// job can stall for long stretches (e.g. first-run dataset download) while
+	// still running server-side, and giving up here would also drop the pending
+	// --eval dispatch (EN-2398). On a no-progress timeout, warn and keep waiting
+	// up to maxWaitForImportModelJob; ctx cancellation surfaces as ErrorTimeout
+	// from the waiter, so check ctx.Err() to abort on Ctrl+C.
+	start := time.Now()
+	for {
+		err = waitForSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_IMPORT_MODEL_JOB)
+		if err != api.ErrorTimeout || ctx.Err() != nil || time.Since(start) >= maxWaitForImportModelJob {
+			break
+		}
+		log.Warnf("No progress from the %s job in the last %s — it may still be running on the server; continuing to wait (Ctrl+C to stop)...", resultLabel, TIMEOUT_FOR_IMPORT_MODEL_JOB)
+	}
 
 	if err == api.ErrorTimeout {
 		return false, nil, ErrImportModelTimeout

--- a/pkg/model/api_test.go
+++ b/pkg/model/api_test.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tensorleap/leap-cli/pkg/api"
+	"github.com/tensorleap/leap-cli/pkg/log"
+)
+
+func stubWaiter(calls *int, results ...error) func(context.Context, func() (bool, []log.Step, error), time.Duration, time.Duration) error {
+	return func(context.Context, func() (bool, []log.Step, error), time.Duration, time.Duration) error {
+		*calls++
+		if *calls <= len(results) {
+			return results[*calls-1]
+		}
+		return results[len(results)-1]
+	}
+}
+
+func TestWaitForImportModelJobRetriesOnNoProgressTimeout(t *testing.T) {
+	orig := waitForSteps
+	defer func() { waitForSteps = orig }()
+
+	calls := 0
+	waitForSteps = stubWaiter(&calls, api.ErrorTimeout, api.ErrorTimeout, nil)
+
+	ok, _, err := waitForImportModelJob(context.Background(), "p", "j", "push")
+	if err != nil || !ok {
+		t.Fatalf("expected success after retries, got ok=%v err=%v", ok, err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 waiter calls, got %d", calls)
+	}
+}
+
+func TestWaitForImportModelJobStopsOnCancelledContext(t *testing.T) {
+	orig := waitForSteps
+	defer func() { waitForSteps = orig }()
+
+	calls := 0
+	waitForSteps = stubWaiter(&calls, api.ErrorTimeout)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := waitForImportModelJob(ctx, "p", "j", "push")
+	if !errors.Is(err, ErrImportModelTimeout) {
+		t.Fatalf("expected ErrImportModelTimeout, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected no retry on cancelled context, got %d calls", calls)
+	}
+}
+
+func TestWaitForImportModelJobRespectsAbsoluteCap(t *testing.T) {
+	origWait, origMax := waitForSteps, maxWaitForImportModelJob
+	defer func() { waitForSteps, maxWaitForImportModelJob = origWait, origMax }()
+
+	maxWaitForImportModelJob = 0
+	calls := 0
+	waitForSteps = stubWaiter(&calls, api.ErrorTimeout)
+
+	_, _, err := waitForImportModelJob(context.Background(), "p", "j", "push")
+	if !errors.Is(err, ErrImportModelTimeout) {
+		t.Fatalf("expected ErrImportModelTimeout, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 waiter call at zero cap, got %d", calls)
+	}
+}

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -106,8 +106,8 @@ type VersionInfo struct {
 	Status           VersionStatus
 }
 
-func AskUserForModelPathOrOverwrite(ctx context.Context, projectId string, currentName *string, runEval bool) (isOverwrite bool, overwriteVersionInfo *VersionInfo, modelPath string, err error) {
-	overwriteVersionInfo, err = AskUserForNewVersionOrSelectExistingVersion(ctx, projectId, runEval)
+func AskUserForModelPathOrOverwrite(ctx context.Context, projectId string, currentName *string) (isOverwrite bool, overwriteVersionInfo *VersionInfo, modelPath string, err error) {
+	overwriteVersionInfo, err = AskUserForNewVersionOrSelectExistingVersion(ctx, projectId)
 	if err != nil {
 		return false, nil, "", err
 	}
@@ -132,7 +132,7 @@ func AskUserForModelPathOrOverwrite(ctx context.Context, projectId string, curre
 	return false, nil, modelPath, nil
 }
 
-func AskUserForNewVersionOrSelectExistingVersion(ctx context.Context, projectId string, runEval bool) (*VersionInfo, error) {
+func AskUserForNewVersionOrSelectExistingVersion(ctx context.Context, projectId string) (*VersionInfo, error) {
 
 	versions, err := GetSlimActiveVersions(ctx, projectId)
 	if err != nil {
@@ -177,16 +177,6 @@ func AskUserForNewVersionOrSelectExistingVersion(ctx context.Context, projectId 
 	selectedIndex := 0
 	hasOptions := len(options) > 1
 	if hasOptions {
-
-		// Only surface the eval hint when the caller didn't pass --eval:
-		// with --eval the diff is auto-detected and patched / re-evaluated
-		// for them; without --eval we want users to know that overwriting
-		// alone just replaces the version and they can drive evaluation
-		// from the UI afterwards.
-		if !runEval {
-			fmt.Println(text.FgYellow.Sprint("\n\n NOTE: Overwriting replaces the version. Use the update-evaluate dialog in the UI to re-evaluate (or re-run with --eval). \n\n"))
-		}
-
 		prompt := &survey.Select{
 			Message: "Push as new, or overwrite existing",
 			Options: options,


### PR DESCRIPTION
## What

Two changes to `leap push`:

1. **EN-2398 — `leap push --eval` losing the eval on first run.** The 60-minute wait timeout in `WaitForPushJob` is a *no-progress* window (the timer resets only when the job's reported steps change). A push job stalled on a slow step — e.g. the first-run dataset download after a fresh install — tripped it, the CLI gave up, and the pending `--eval` dispatch was silently dropped even though the push job later succeeded server-side. Now, on a no-progress timeout the CLI warns and keeps waiting (bounded by a 6h total cap); Ctrl+C / context cancellation still aborts immediately. The evaluate then dispatches once the push job lands.

2. **EN-2417 — redundant note in the version picker.** Removed the yellow "NOTE: Overwriting replaces the version…" message — the end-of-push "Run evaluate after push?" prompt already covers it. The `runEval` parameter of `AskUserForModelPathOrOverwrite` / `AskUserForNewVersionOrSelectExistingVersion` existed only to gate that note, so it's removed too.

## How

- `pkg/model/api.go`: `waitForImportModelJob` retries `WaitForConditionWithSteps` on `ErrorTimeout` with a warning, up to `maxWaitForImportModelJob` (6h); breaks on `ctx.Err()` since the shared waiter conflates cancellation with timeout. Tests cover retry-then-success, cancelled context, and the absolute cap via a stubbed waiter seam.
- `pkg/model/utils.go`, `cmd/root_cmd/push.go`: note + dead parameter removal.

## Notes

- Supersedes #257 (timeout bump to 90m) — the stall no longer kills the wait at all.
- The full DoD from the original Slack thread (eval surviving CLI death entirely) needs server-side eval chaining in the push job; out of scope here.

Closes EN-2398, EN-2417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)