### PR TITLE
push: stream pippin build logs under the Build Dependencies step

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/samber/lo v1.51.0
@@ -42,7 +43,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect

--- a/pkg/api/steps_test.go
+++ b/pkg/api/steps_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/tensorleap/leap-cli/pkg/log"
+	"github.com/tensorleap/leap-cli/pkg/tensorleapapi"
+)
+
+// The log tail is scoped by event id, so the id has to survive the conversion —
+// matching on the display name would break the moment anyone rewords it.
+func TestStepsFromJobCarriesEventID(t *testing.T) {
+	job := &tensorleapapi.Job{
+		EventsSnapshot: &tensorleapapi.EventsSnapshot{
+			Events: []tensorleapapi.JobEvent{
+				{
+					Id:     "build_dependencies",
+					Name:   "Build Dependencies Preprocess",
+					Status: tensorleapapi.STATUSENUM_STARTED,
+				},
+			},
+		},
+	}
+
+	steps := StepsFromJob(job)
+
+	if len(steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(steps))
+	}
+	if steps[0].ID != "build_dependencies" {
+		t.Errorf("got ID %q, want %q", steps[0].ID, "build_dependencies")
+	}
+	if steps[0].Status != log.StepStatusRunning {
+		t.Errorf("got status %q, want %q", steps[0].Status, log.StepStatusRunning)
+	}
+}
+
+// Regression: this iterated by value over a slice of a value type, so the
+// status assignment landed on a copy and the slice was never modified.
+func TestMarkLastStepAsFailedMutatesSlice(t *testing.T) {
+	steps := []log.Step{
+		{ID: "a", Status: log.StepStatusDone},
+		{ID: "b", Status: log.StepStatusSkipped},
+		{ID: "c", Status: log.StepStatusRunning},
+		{ID: "d", Status: log.StepStatusPending},
+	}
+
+	markLastStepAsFailed(steps)
+
+	if steps[2].Status != log.StepStatusFailed {
+		t.Errorf("expected the first unfinished step to be FAILED, got %q", steps[2].Status)
+	}
+	if steps[3].Status != log.StepStatusPending {
+		t.Errorf("expected later steps untouched, got %q", steps[3].Status)
+	}
+	if steps[0].Status != log.StepStatusDone || steps[1].Status != log.StepStatusSkipped {
+		t.Error("expected terminal-success steps untouched")
+	}
+}

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -332,6 +332,7 @@ func StepsFromJob(job *tensorleapapi.Job) []log.Step {
 			total = event.Progress.Total
 		}
 		jobSteps = append(jobSteps, log.Step{
+			ID:      event.Id,
 			Name:    event.Name,
 			Status:  mapStatus(event.Status),
 			Current: current,

--- a/pkg/api/wait.go
+++ b/pkg/api/wait.go
@@ -48,7 +48,29 @@ func stepsFingerprint(steps []log.Step) string {
 	return result
 }
 
-func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []log.Step, error), sleepDuration time.Duration, timeoutDuration time.Duration) error {
+// LogTail streams the output of one long-running step beneath the step list,
+// for steps whose progress isn't visible from status alone. Fetch is called
+// only while the step identified by StepID is RUNNING.
+type LogTail struct {
+	StepID string
+	Fetch  func() ([]string, error)
+}
+
+// logTailFetchEvery throttles the tail relative to the step poll. At the usual
+// 3s poll that's a refresh roughly every 6s, matching the web UI's cadence.
+const logTailFetchEvery = 2
+
+// BuildDependenciesStepID is the server-side event id for pippin's dependency
+// build — the only step whose logs we stream today. Mirrors
+// BUILD_DEPENDENCIES_EVENT_ID in node-server and the id the engine scheduler
+// publishes.
+//
+// ponytail: a one-element set lives here rather than as a job-event field. If a
+// second step ever wants a tail, move the decision server-side so changing it
+// doesn't need a CLI release.
+const BuildDependenciesStepID = "build_dependencies"
+
+func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []log.Step, error), sleepDuration time.Duration, timeoutDuration time.Duration, tail *LogTail) error {
 	lastProgressTime := time.Now()
 	lastFingerprint := ""
 
@@ -57,6 +79,7 @@ func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []lo
 	defer renderer.Stop()
 
 	var doneTime *time.Time
+	poll := 0
 
 	for time.Since(lastProgressTime) < timeoutDuration {
 		select {
@@ -64,6 +87,7 @@ func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []lo
 			return ErrorTimeout
 		default:
 			done, steps, err := condition()
+			poll++
 			if len(steps) == 0 && renderer.IsTTY {
 				status := log.StepStatusRunning
 				if done {
@@ -89,6 +113,7 @@ func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []lo
 				return err
 			}
 			renderer.Update(steps)
+			updateLogTail(renderer, tail, steps, poll)
 
 			if done {
 				isAllStepsDone := isAllStepsEnded(steps)
@@ -113,6 +138,50 @@ func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []lo
 	return ErrorTimeout
 }
 
+// updateLogTail refreshes the tail while its step is running, and takes it down
+// once the step ends — except on failure, where the last lines are the most
+// useful thing on screen and are left frozen for the error report that follows.
+func updateLogTail(renderer *log.Renderer, tail *LogTail, steps []log.Step, poll int) {
+	if tail == nil || tail.Fetch == nil {
+		return
+	}
+
+	// No step, no tail — the engine replaces the whole events array when it
+	// takes over, so a vanished step must not leave stale output on screen.
+	step := findStep(steps, tail.StepID)
+	if step == nil {
+		renderer.UpdateLogs(nil)
+		return
+	}
+
+	if step.Status != log.StepStatusRunning {
+		if step.Status != log.StepStatusFailed {
+			renderer.UpdateLogs(nil)
+		}
+		return
+	}
+
+	if poll%logTailFetchEvery != 0 {
+		return
+	}
+
+	lines, err := tail.Fetch()
+	if err != nil {
+		// The tail is decoration — a failed fetch must never fail the wait.
+		return
+	}
+	renderer.UpdateLogs(lines)
+}
+
+func findStep(steps []log.Step, id string) *log.Step {
+	for i := range steps {
+		if steps[i].ID == id {
+			return &steps[i]
+		}
+	}
+	return nil
+}
+
 // Terminal-success step statuses — work is done or was intentionally
 // skipped. Treated equivalently when deciding whether the run is over
 // or where to mark the failure when one occurs.
@@ -121,9 +190,11 @@ func isStepStatusSucceeded(status log.StepStatus) bool {
 }
 
 func markLastStepAsFailed(steps []log.Step) {
-	for _, step := range steps {
-		if !isStepStatusSucceeded(step.Status) {
-			step.Status = log.StepStatusFailed
+	// Index, not range-copy: log.Step is a value type, so assigning to the loop
+	// variable updated a copy and left the slice untouched.
+	for i := range steps {
+		if !isStepStatusSucceeded(steps[i].Status) {
+			steps[i].Status = log.StepStatusFailed
 			break
 		}
 	}

--- a/pkg/api/wait.go
+++ b/pkg/api/wait.go
@@ -56,7 +56,10 @@ type LogTail struct {
 	Fetch  func() ([]string, error)
 }
 
-// logTailFetchEvery throttles the tail relative to the step poll. At the usual
+// logTailFetchEvery throttles the tail relative to the step poll. Fetching the
+// tail is far more expensive than the status poll it rides along with — the
+// server reads thousands of log lines per container and shells out to `kubectl
+// describe` — so it runs on every other poll rather than every one. At the usual
 // 3s poll that's a refresh roughly every 6s, matching the web UI's cadence.
 const logTailFetchEvery = 2
 
@@ -113,7 +116,9 @@ func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []lo
 				return err
 			}
 			renderer.Update(steps)
-			updateLogTail(renderer, tail, steps, poll)
+			// Only the fetch is throttled; updateLogTail still runs every poll so
+			// it can take the tail down promptly when the step ends.
+			updateLogTail(renderer, tail, steps, poll%logTailFetchEvery == 0)
 
 			if done {
 				isAllStepsDone := isAllStepsEnded(steps)
@@ -141,7 +146,12 @@ func WaitForConditionWithSteps(ctx context.Context, condition func() (bool, []lo
 // updateLogTail refreshes the tail while its step is running, and takes it down
 // once the step ends — except on failure, where the last lines are the most
 // useful thing on screen and are left frozen for the error report that follows.
-func updateLogTail(renderer *log.Renderer, tail *LogTail, steps []log.Step, poll int) {
+//
+// mayFetch is the caller's throttle: taking the tail down is cheap and happens
+// on every call, but fetching is expensive, so the caller decides when to offer
+// it. This function may still decline — there's nothing to fetch unless the step
+// is running.
+func updateLogTail(renderer *log.Renderer, tail *LogTail, steps []log.Step, mayFetch bool) {
 	if tail == nil || tail.Fetch == nil {
 		return
 	}
@@ -161,7 +171,7 @@ func updateLogTail(renderer *log.Renderer, tail *LogTail, steps []log.Step, poll
 		return
 	}
 
-	if poll%logTailFetchEvery != 0 {
+	if !mayFetch {
 		return
 	}
 

--- a/pkg/code/api.go
+++ b/pkg/code/api.go
@@ -160,7 +160,7 @@ func WaitForCodeIntegrationStatus(ctx context.Context, projectId, codeSnapshotId
 		return false, steps, nil
 	}
 
-	err := api.WaitForConditionWithSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_CODE_INTEGRATION_STATUS)
+	err := api.WaitForConditionWithSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_CODE_INTEGRATION_STATUS, nil)
 
 	if err == api.ErrorTimeout {
 		return false, ErrCodeIntegrationTimeout

--- a/pkg/log/log_steps.go
+++ b/pkg/log/log_steps.go
@@ -16,6 +16,10 @@ import (
 // -----------------------------
 
 type Step struct {
+	// ID is the server-side event id (e.g. "build_dependencies"). Stable across
+	// wording changes to Name, so behaviour keyed off a specific step matches on
+	// this rather than on the display label.
+	ID      string
 	Name    string
 	Status  StepStatus
 	Current float64
@@ -34,6 +38,7 @@ type Job struct {
 type rendererImpl interface {
 	Start()
 	Update(steps []Step)
+	UpdateLogs(lines []string)
 	Stop()
 }
 
@@ -55,21 +60,23 @@ func NewRenderer() *Renderer {
 	return &Renderer{impl: newLogRenderer(), IsTTY: false}
 }
 
-func (r *Renderer) Start()              { r.impl.Start() }
-func (r *Renderer) Update(steps []Step) { r.impl.Update(steps) }
-func (r *Renderer) Stop()               { r.impl.Stop() }
+func (r *Renderer) Start()                    { r.impl.Start() }
+func (r *Renderer) Update(steps []Step)       { r.impl.Update(steps) }
+func (r *Renderer) UpdateLogs(lines []string) { r.impl.UpdateLogs(lines) }
+func (r *Renderer) Stop()                     { r.impl.Stop() }
 
 // ====================================================================
 // TTY RENDERER (interactive spinner + in-place updates)
 // ====================================================================
 
 type ttyRenderer struct {
-	mu      sync.Mutex
-	writer  *blockWriter
-	steps   []Step
-	stepMap map[string]*Step
-	stopCh  chan struct{}
-	done    bool
+	mu       sync.Mutex
+	writer   *blockWriter
+	steps    []Step
+	stepMap  map[string]*Step
+	logLines []string
+	stopCh   chan struct{}
+	done     bool
 }
 
 func newTTYRenderer() *ttyRenderer {
@@ -137,12 +144,24 @@ func (r *ttyRenderer) Update(steps []Step) {
 	r.stepMap = newMap
 }
 
-func (r *ttyRenderer) redraw(spin string) {
-	lines := r.renderLines(spin)
-	r.writer.Render(lines)
+// UpdateLogs sets the rolling log tail shown beneath the steps. Pass nil to
+// remove it.
+func (r *ttyRenderer) UpdateLogs(lines []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.logLines = lines
 }
 
-func (r *ttyRenderer) renderLines(spin string) []string {
+func (r *ttyRenderer) redraw(spin string) {
+	width := getTerminalWidth()
+	lines := r.renderLines(spin, width)
+	r.writer.Render(lines, width)
+}
+
+// logGutter keeps the tail visually subordinate to the steps above it.
+var logGutter = text.FgHiBlack.Sprint("│")
+
+func (r *ttyRenderer) renderLines(spin string, width int) []string {
 	lines := []string{}
 
 	for _, s := range r.steps {
@@ -151,6 +170,28 @@ func (r *ttyRenderer) renderLines(spin string) []string {
 			icon = text.FgHiBlue.Sprint(spin)
 		}
 		lines = append(lines, printStepStatus(s, icon))
+	}
+
+	if len(r.logLines) == 0 {
+		return lines
+	}
+
+	// The whole block is cursor-addressed, so it has to fit on screen —
+	// clearPreviousLines can't reach rows that have scrolled off the top.
+	height := LogTailHeight
+	if max := getTerminalHeight() / 3; height > max {
+		height = max
+	}
+	// "  │ " prefix; the tail wraps to the remaining columns.
+	const gutterWidth = 4
+	tailWidth := width - gutterWidth
+	if height < 1 || tailWidth < 1 {
+		return lines
+	}
+
+	lines = append(lines, "")
+	for _, row := range fixedTail(r.logLines, height, tailWidth) {
+		lines = append(lines, "  "+logGutter+" "+row)
 	}
 	return lines
 }
@@ -162,15 +203,24 @@ func (r *ttyRenderer) renderLines(spin string) []string {
 type blockWriter struct {
 	mu        sync.Mutex
 	lineCount int
+	lastWidth int
 }
 
 func newBlockWriter() *blockWriter { return &blockWriter{} }
 
-func (bw *blockWriter) Render(lines []string) {
+// Render repaints the block in place. Callers must pass only lines that fit
+// within width — lineCount counts strings while clearPreviousLines erases rows,
+// so a wrapped line would leave debris behind on every frame.
+func (bw *blockWriter) Render(lines []string, width int) {
 	bw.mu.Lock()
 	defer bw.mu.Unlock()
 
-	if bw.lineCount > 0 {
+	// On resize the terminal re-flows rows we already printed, so lineCount no
+	// longer describes what's on screen and erasing would eat the wrong rows.
+	// Leaving one stale block behind beats accumulating debris every frame.
+	resized := bw.lastWidth != 0 && bw.lastWidth != width
+
+	if bw.lineCount > 0 && !resized {
 		clearPreviousLines(bw.lineCount)
 	}
 
@@ -178,6 +228,7 @@ func (bw *blockWriter) Render(lines []string) {
 		fmt.Println(ln)
 	}
 	bw.lineCount = len(lines)
+	bw.lastWidth = width
 }
 
 func clearPreviousLines(n int) {
@@ -195,11 +246,13 @@ type logRenderer struct {
 	mu          sync.Mutex
 	lastPrinted map[string]Step
 	steps       []Step
+	printedLogs map[string]bool
 }
 
 func newLogRenderer() *logRenderer {
 	return &logRenderer{
 		lastPrinted: make(map[string]Step),
+		printedLogs: make(map[string]bool),
 	}
 }
 
@@ -222,6 +275,22 @@ func (r *logRenderer) Update(steps []Step) {
 			fmt.Println(printStepStatus(s, diffIcon(s.Status)))
 			r.lastPrinted[s.Name] = s
 		}
+	}
+}
+
+// UpdateLogs appends log lines not yet seen. A rolling window is meaningless
+// when the output is a file or CI log, so each line is printed once instead.
+func (r *logRenderer) UpdateLogs(lines []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, line := range lines {
+		clean := sanitizeLine(line)
+		if clean == "" || r.printedLogs[clean] {
+			continue
+		}
+		r.printedLogs[clean] = true
+		fmt.Printf("    | %s\n", clean)
 	}
 }
 

--- a/pkg/log/log_tail.go
+++ b/pkg/log/log_tail.go
@@ -1,0 +1,102 @@
+package log
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/term"
+)
+
+// LogTailHeight is how many terminal rows the tail occupies. Rows, not log
+// lines — a long line wraps and spends more than one of them.
+const LogTailHeight = 5
+
+const defaultTerminalWidth = 80
+
+// tabWidth matches the near-universal terminal default. Tabs are expanded here
+// because a wrapper counting cells can't know the terminal's real tab stops.
+const tabWidth = 8
+
+// csiSequence matches CSI escape sequences (colour, but also cursor movement
+// and erase). Log content is echoed into the user's terminal, so sequences that
+// move the cursor would break blockWriter's row arithmetic — strip all of them
+// rather than trying to allow-list the harmless ones.
+var csiSequence = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+// otherEscape catches the non-CSI escape forms (OSC, single-char escapes) left
+// over after csiSequence.
+var otherEscape = regexp.MustCompile(`\x1b[]PX^_][^\x1b]*(?:\x1b\\|\x07)?|\x1b.`)
+
+func getTerminalWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || width <= 0 {
+		return defaultTerminalWidth
+	}
+	return width
+}
+
+// sanitizeLine makes a raw log line safe to print inside a cursor-addressed
+// block: no escape sequences the terminal would act on, no carriage returns
+// jumping to column 0, and tabs expanded so width measurement is honest.
+func sanitizeLine(line string) string {
+	line = csiSequence.ReplaceAllString(line, "")
+	line = otherEscape.ReplaceAllString(line, "")
+
+	var b strings.Builder
+	col := 0
+	for _, r := range line {
+		switch {
+		case r == '\t':
+			pad := tabWidth - (col % tabWidth)
+			b.WriteString(strings.Repeat(" ", pad))
+			col += pad
+		case r == '\r' || r == '\n':
+			// Dropped, not replaced: \r would jump the cursor to column 0 and
+			// overwrite the row; \n would desync lineCount from rows printed.
+		case r < 0x20 || r == 0x7f:
+			// Remaining C0 controls and DEL — no width, unpredictable effect.
+		default:
+			b.WriteRune(r)
+			col++
+		}
+	}
+	return b.String()
+}
+
+// toRows sanitizes and hard-wraps a log line into one string per terminal row.
+// Every returned string is guaranteed to fit the width, which is what keeps
+// blockWriter's "one string == one row" assumption true.
+func toRows(line string, width int) []string {
+	if width <= 0 {
+		width = defaultTerminalWidth
+	}
+	clean := sanitizeLine(line)
+	if clean == "" {
+		return []string{""}
+	}
+	return strings.Split(ansi.Hardwrap(clean, width, true), "\n")
+}
+
+// fixedTail renders log lines as exactly n terminal rows, showing the most
+// recent output and padding with blanks so the block height never changes
+// between frames (a block that changes height visibly jitters).
+func fixedTail(lines []string, n, width int) []string {
+	if n <= 0 {
+		return nil
+	}
+
+	rows := make([]string, 0, n)
+	for _, line := range lines {
+		rows = append(rows, toRows(line, width)...)
+	}
+
+	out := make([]string, n)
+	start := len(rows) - n
+	if start < 0 {
+		start = 0
+	}
+	copy(out, rows[start:])
+	return out
+}

--- a/pkg/log/log_tail_test.go
+++ b/pkg/log/log_tail_test.go
@@ -1,0 +1,150 @@
+package log
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The invariant blockWriter depends on: every string it prints occupies exactly
+// one terminal row. If a row is wider than the terminal it wraps, and
+// clearPreviousLines then erases too few rows and strands output every frame.
+func assertFitsWidth(t *testing.T, rows []string, width int) {
+	t.Helper()
+	for i, row := range rows {
+		if w := ansi.StringWidth(row); w > width {
+			t.Errorf("row %d is %d cells wide, exceeds width %d: %q", i, w, width, row)
+		}
+	}
+}
+
+func TestToRowsWrapsToWidth(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		width    int
+		wantRows int
+	}{
+		{"short line stays one row", "Collecting torch", 40, 1},
+		{"exact width stays one row", strings.Repeat("a", 40), 40, 1},
+		{"one over wraps to two", strings.Repeat("a", 41), 40, 2},
+		{"three times width", strings.Repeat("a", 120), 40, 3},
+		{"empty line is one blank row", "", 40, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := toRows(tt.line, tt.width)
+			if len(rows) != tt.wantRows {
+				t.Errorf("got %d rows, want %d: %q", len(rows), tt.wantRows, rows)
+			}
+			assertFitsWidth(t, rows, tt.width)
+		})
+	}
+}
+
+func TestToRowsNeutralizesControlSequences(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			// Would move the cursor two rows up and corrupt the whole block.
+			name: "cursor movement stripped",
+			line: "before\x1b[2Aafter",
+			want: "beforeafter",
+		},
+		{
+			name: "colour stripped",
+			line: "\x1b[33mwarning\x1b[0m",
+			want: "warning",
+		},
+		{
+			// Would jump to column 0 and overwrite the row in place.
+			name: "carriage return dropped",
+			line: "progress 50%\rprogress 100%",
+			want: "progress 50%progress 100%",
+		},
+		{
+			name: "tab expanded to next stop",
+			line: "ab\tc",
+			want: "ab      c",
+		},
+		{
+			name: "indentation preserved",
+			line: "  Downloading torch",
+			want: "  Downloading torch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := toRows(tt.line, 200)
+			got := strings.Join(rows, "")
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToRowsWideCharactersFitWidth(t *testing.T) {
+	// Full-width runes are one rune but two cells; a rune-counting wrapper
+	// would emit rows twice as wide as the terminal.
+	rows := toRows(strings.Repeat("生", 40), 20)
+	assertFitsWidth(t, rows, 20)
+}
+
+func TestFixedTailAlwaysReturnsNRows(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		n     int
+	}{
+		{"fewer lines than rows", []string{"a", "b"}, 5},
+		{"exactly n lines", []string{"a", "b", "c", "d", "e"}, 5},
+		{"more lines than rows", []string{"a", "b", "c", "d", "e", "f", "g"}, 5},
+		{"no lines", nil, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fixedTail(tt.lines, tt.n, 40)
+			if len(got) != tt.n {
+				t.Errorf("got %d rows, want %d", len(got), tt.n)
+			}
+			assertFitsWidth(t, got, 40)
+		})
+	}
+}
+
+func TestFixedTailKeepsMostRecent(t *testing.T) {
+	got := fixedTail([]string{"a", "b", "c", "d", "e", "f", "g"}, 3, 40)
+	want := []string{"e", "f", "g"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFixedTailLongLineConsumesMultipleRows(t *testing.T) {
+	// A line three widths long should occupy three of the five slots, leaving
+	// room for only the two most recent short lines before it.
+	long := strings.Repeat("x", 120)
+	got := fixedTail([]string{"a", "b", "c", long}, 5, 40)
+
+	if len(got) != 5 {
+		t.Fatalf("got %d rows, want 5", len(got))
+	}
+	if got[0] != "b" || got[1] != "c" {
+		t.Errorf("expected the two newest short lines before the long one, got %q, %q", got[0], got[1])
+	}
+	for i := 2; i < 5; i++ {
+		if got[i] != strings.Repeat("x", 40) {
+			t.Errorf("row %d: expected a full-width chunk of the long line, got %q", i, got[i])
+		}
+	}
+}

--- a/pkg/model/api.go
+++ b/pkg/model/api.go
@@ -222,6 +222,15 @@ func waitForImportModelJob(ctx context.Context, projectId, importModelJobId, res
 		return false, steps, nil
 	}
 
+	// Pippin's dependency build can run for tens of minutes with no step-level
+	// change, so stream its output to show the push isn't stuck.
+	buildLogTail := &api.LogTail{
+		StepID: api.BuildDependenciesStepID,
+		Fetch: func() ([]string, error) {
+			return run.GetBuildLogTail(ctx, importModelJobId, log.LogTailHeight)
+		},
+	}
+
 	// TIMEOUT_FOR_IMPORT_MODEL_JOB is a no-progress window, not a total cap: the
 	// job can stall for long stretches (e.g. first-run dataset download) while
 	// still running server-side, and giving up here would also drop the pending
@@ -230,7 +239,7 @@ func waitForImportModelJob(ctx context.Context, projectId, importModelJobId, res
 	// from the waiter, so check ctx.Err() to abort on Ctrl+C.
 	start := time.Now()
 	for {
-		err = waitForSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_IMPORT_MODEL_JOB)
+		err = waitForSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_IMPORT_MODEL_JOB, buildLogTail)
 		if err != api.ErrorTimeout || ctx.Err() != nil || time.Since(start) >= maxWaitForImportModelJob {
 			break
 		}

--- a/pkg/model/api_test.go
+++ b/pkg/model/api_test.go
@@ -10,13 +10,41 @@ import (
 	"github.com/tensorleap/leap-cli/pkg/log"
 )
 
-func stubWaiter(calls *int, results ...error) func(context.Context, func() (bool, []log.Step, error), time.Duration, time.Duration) error {
-	return func(context.Context, func() (bool, []log.Step, error), time.Duration, time.Duration) error {
+func stubWaiter(calls *int, results ...error) func(context.Context, func() (bool, []log.Step, error), time.Duration, time.Duration, *api.LogTail) error {
+	return func(context.Context, func() (bool, []log.Step, error), time.Duration, time.Duration, *api.LogTail) error {
 		*calls++
 		if *calls <= len(results) {
 			return results[*calls-1]
 		}
 		return results[len(results)-1]
+	}
+}
+
+// The push flow waits here, not in code.WaitForCodeIntegrationStatus, so this
+// is where the pippin log tail has to be attached. Regression: it was wired
+// into the code package, which nothing calls, and this path passed nil.
+func TestWaitForImportModelJobAttachesBuildDependenciesLogTail(t *testing.T) {
+	orig := waitForSteps
+	defer func() { waitForSteps = orig }()
+
+	var got *api.LogTail
+	waitForSteps = func(_ context.Context, _ func() (bool, []log.Step, error), _ time.Duration, _ time.Duration, tail *api.LogTail) error {
+		got = tail
+		return nil
+	}
+
+	if _, _, err := waitForImportModelJob(context.Background(), "p", "job-123", "push"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got == nil {
+		t.Fatal("expected a log tail to be attached to the push wait, got nil")
+	}
+	if got.StepID != api.BuildDependenciesStepID {
+		t.Errorf("got StepID %q, want %q", got.StepID, api.BuildDependenciesStepID)
+	}
+	if got.Fetch == nil {
+		t.Error("expected a non-nil Fetch on the log tail")
 	}
 }
 

--- a/pkg/project/api.go
+++ b/pkg/project/api.go
@@ -221,7 +221,7 @@ func ExportProject(ctx context.Context, projectId string, copyToUrl string, opti
 		}
 
 		return false, steps, nil
-	}, 20*time.Second, TIMEOUT_FOR_PROJECT_PUBLISH)
+	}, 20*time.Second, TIMEOUT_FOR_PROJECT_PUBLISH, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for project to be copied: %v", err)
@@ -308,7 +308,7 @@ func waitForImportProjectJob(ctx context.Context, jobId string) error {
 
 		return false, steps, nil
 	}
-	err := api.WaitForConditionWithSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_IMPORT_PROJECT_JOB)
+	err := api.WaitForConditionWithSteps(ctx, condition, sleepDuration, TIMEOUT_FOR_IMPORT_PROJECT_JOB, nil)
 	if err != nil {
 		return fmt.Errorf("failed to wait for the import project job status: %v", err)
 	}

--- a/pkg/run/build_logs.go
+++ b/pkg/run/build_logs.go
@@ -1,0 +1,83 @@
+package run
+
+import (
+	"context"
+	"regexp"
+	"strings"
+)
+
+// Pippin (the dependency-builder init container) logs through Python's logging
+// module, so every line carries a timestamp and level, and BuildKit output
+// carries a second prefix on top of that.
+var (
+	pippinLogPrefix = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - \w+ - `)
+	buildKitPrefix  = regexp.MustCompile(`^\[BuildKit\] `)
+)
+
+// dropLine matches pippin output that must never reach the user's terminal.
+var dropLine = []*regexp.Regexp{
+	// Pippin's own log rate limiter — an artifact of our plumbing, not the build.
+	regexp.MustCompile(`lines suppressed \(log rate limit\)`),
+	// Presigned download URL for the dependency archive.
+	regexp.MustCompile(`(?i)DEPENDENCY_URL`),
+	// Any other signed URL that shows up in the build output.
+	regexp.MustCompile(`[?&](X-Amz-Signature|Signature|sig)=`),
+}
+
+// CleanBuildLogLines strips log framing and drops lines that are noise or
+// unsafe to display, preserving order. Complements GetTopLogs, which keeps
+// lines matching a pattern; this one drops them.
+func CleanBuildLogLines(raw []string) []string {
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		line = pippinLogPrefix.ReplaceAllString(line, "")
+		line = buildKitPrefix.ReplaceAllString(line, "")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if shouldDrop(line) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func shouldDrop(line string) bool {
+	for _, pat := range dropLine {
+		if pat.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetBuildLogTail fetches the job's pod logs and returns the last `count`
+// displayable lines. While the dependency-builder init container is running the
+// engine container hasn't started, so the pod's log is pippin's output.
+func GetBuildLogTail(ctx context.Context, jobId string, count int) ([]string, error) {
+	podLogs, err := GetRunLogs(ctx, jobId)
+	if err != nil {
+		return nil, err
+	}
+
+	var lines []string
+	for _, podLog := range podLogs {
+		if isDescribeLog(podLog.Name) {
+			continue
+		}
+		lines = append(lines, strings.Split(podLog.Logs, "\n")...)
+	}
+
+	lines = CleanBuildLogLines(lines)
+	if len(lines) > count {
+		lines = lines[len(lines)-count:]
+	}
+	return lines, nil
+}
+
+// getPodLogs appends a `describe-<pod>` entry alongside the real logs; it's
+// kubectl-describe output, not build progress.
+func isDescribeLog(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), "describe")
+}

--- a/pkg/run/build_logs_test.go
+++ b/pkg/run/build_logs_test.go
@@ -1,0 +1,106 @@
+package run
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanBuildLogLinesStripsFraming(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "python logging prefix",
+			line: "2026-01-15 10:32:01,441 - INFO - Building image with BuildKit",
+			want: "Building image with BuildKit",
+		},
+		{
+			name: "buildkit prefix on top of logging prefix",
+			line: "2026-01-15 10:32:01,441 - INFO - [BuildKit] #8 12.4 Collecting torch",
+			want: "#8 12.4 Collecting torch",
+		},
+		{
+			name: "unframed line passes through",
+			line: "#8 DONE 1204.7s",
+			want: "#8 DONE 1204.7s",
+		},
+		{
+			name: "indentation preserved after stripping",
+			line: "2026-01-15 10:32:01,441 - INFO - [BuildKit] #8   Downloading torch",
+			want: "#8   Downloading torch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CleanBuildLogLines([]string{tt.line})
+			if len(got) != 1 {
+				t.Fatalf("got %d lines, want 1: %q", len(got), got)
+			}
+			if got[0] != tt.want {
+				t.Errorf("got %q, want %q", got[0], tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanBuildLogLinesDropsNoise(t *testing.T) {
+	dropped := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "rate limiter bookkeeping",
+			line: "2026-01-15 10:32:01,441 - INFO - [BuildKit] ... 4213 lines suppressed (log rate limit) ...",
+		},
+		{
+			name: "blank line",
+			line: "   ",
+		},
+	}
+
+	for _, tt := range dropped {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CleanBuildLogLines([]string{tt.line}); len(got) != 0 {
+				t.Errorf("expected line to be dropped, got %q", got)
+			}
+		})
+	}
+}
+
+// The dependency archive URL is presigned — it must never reach the user's
+// terminal or scrollback.
+func TestCleanBuildLogLinesRedactsSignedUrls(t *testing.T) {
+	lines := []string{
+		"2026-01-15 10:32:01,441 - INFO - DEPENDENCY_URL: https://bucket.s3.amazonaws.com/deps.tar.gz?X-Amz-Signature=deadbeef",
+		"2026-01-15 10:32:01,441 - INFO - Downloading dependency archive from https://bucket.s3.amazonaws.com/deps.tar.gz?X-Amz-Signature=deadbeef",
+		"2026-01-15 10:32:01,441 - INFO - Collecting torch",
+	}
+
+	got := CleanBuildLogLines(lines)
+
+	for _, line := range got {
+		if strings.Contains(line, "X-Amz-Signature") || strings.Contains(strings.ToUpper(line), "DEPENDENCY_URL") {
+			t.Errorf("signed URL leaked through: %q", line)
+		}
+	}
+	if len(got) != 1 || got[0] != "Collecting torch" {
+		t.Errorf("expected only the safe line to survive, got %q", got)
+	}
+}
+
+func TestCleanBuildLogLinesPreservesOrder(t *testing.T) {
+	got := CleanBuildLogLines([]string{"first", "", "second", "third"})
+	want := []string{"first", "second", "third"}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d: %q", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
[EN-1939](https://tensorleap.atlassian.net/browse/EN-1939)

## Problem

Pushing code with dependencies we haven't built before shows a single `Build Dependencies Preprocess` line, then nothing for 5–40 minutes while pippin builds the image. Nothing distinguishes "installing torch" from "hung", so people kill the push and throw away the partial build.

## What this does

Renders a 5-row rolling tail of pippin's output beneath the step list, only while `build_dependencies` is running, gone once it finishes.

```
  ✔ Parsing code
  ▶ Build Dependencies Preprocess
  • Import Model

  │ #8 142.7   Downloading nvidia_cudnn_cu12-8.9.2.26-py3-none-manyl
  │ inux1_x86_64.whl (731.7 MB)
  │ #8 189.3 Building wheel for opencv-python (pyproject.toml)
  │ #8 402.1   Created wheel for opencv-python
```

## Why it's CLI-only

No engine, node-server, pippin or api-client changes; no republish.

`getJobLogs` already returns init-container logs — `getPodLogs` walks `initContainers` before `containers`, and pippin runs as `image-dependencies-builder`. It's the same endpoint the web UI's LiveLogs panel polls, and the CLI already calls it through `GetRunLogs` for post-failure error context.

`getPodLogs` merges all containers into one blob per pod, which is harmless here: while the init container runs, the engine container hasn't started, so the blob *is* pippin's output.

## Notable bits for review

**Step identity.** `StepsFromJob` was dropping the server's event id, so the only way to recognise a step was its display label — a string hardcoded separately in node-server and the engine scheduler. `log.Step` now carries `ID`, and the tail keys off `build_dependencies`.

**Wrapping, not truncating.** `blockWriter.lineCount` counts *strings* while `clearPreviousLines` erases *rows*. That's been safe only because step names are short; log lines routinely exceed 90 chars and would strand a row every frame. Rather than truncate (loses text) or predict row counts (leaves block height unbounded — `\033[1A` clamps at the top of the screen and can't recover), lines are pre-wrapped to the terminal width so one string is one row by construction. Uses `ansi.Hardwrap`, already an indirect dep via bubbletea/lipgloss — `go.mod` promotes it to direct, no new module or version change.

**Sanitizing is load-bearing, not cosmetic.** Log content is echoed into the user's terminal. A line containing `\x1b[2A` would be *executed* and move the cursor; `\r` jumps to column 0; `\t` renders wider than it measures. Cmake and ninja emit all of these during wheel builds and pippin forwards everything. Stripped before wrapping.

**Redaction.** `DEPENDENCY_URL` is logged at INFO by pippin and is a presigned URL — dropped, with a test asserting it can't leak.

**Resize.** `blockWriter` repaints instead of erasing when the width changes, since the terminal re-flows rows that were already printed correctly. One duplicated block on resize beats accumulating debris.

## Drive-by fix

`markLastStepAsFailed` ranged by value over a slice of a value type, so the status assignment hit a copy and the slice was never modified — a no-op. Included because the tail's freeze-on-failure behaviour depends on a step actually reaching `FAILED`. Covered by a regression test.

## Testing

Unit tests cover the invariant that matters — every string handed to `blockWriter` fits the terminal width — plus the row budget, control-sequence neutralisation, wide characters, the line filter, URL redaction, and that the push wait actually receives the tail.

Manual verification still outstanding:

- [x] Real cache-missing build end to end (change a pinned version to force it)
- [x] ~60-column terminal, resize mid-build
- [x] Non-TTY piped to a file
- [x] Cache hit shows no tail
- [ ] Failure freezes the tail rather than clearing it

## Follow-ups, deliberately not here

- `code.WaitForCodeIntegrationStatus` is exported with **zero callers** — dead since the combined-push change. Worth deleting separately.
- Non-TTY output is a sampled trickle (5 lines per ~6s poll), not a full log. Fine for "it's alive"; `leap run logs` remains the real log.
- If fetch latency proves disruptive, add an optional `tailLines` to `GetJobLogsParams` — the underlying `readNamespacedPodLog` already accepts it. Needs a node-server change plus republish, so not done speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EN-1939]: https://tensorleap.atlassian.net/browse/EN-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ